### PR TITLE
Encrypted topic manual key

### DIFF
--- a/fish_11_dll/src/config/mod.rs
+++ b/fish_11_dll/src/config/mod.rs
@@ -155,6 +155,36 @@ pub use key_management::{
 pub use manual_channel_keys::{
     get_manual_channel_key, list_manual_channel_keys, set_manual_channel_key,
 };
+
+// Helper functions for channel key management
+pub fn has_manual_channel_key(channel_name: &str) -> bool {
+    get_manual_channel_key(channel_name).is_ok()
+}
+
+pub fn has_ratchet_channel_key(channel_name: &str) -> bool {
+    get_ratchet_channel_key(channel_name).is_ok()
+}
+
+pub fn remove_manual_channel_key(channel_name: &str) -> Result<()> {
+    let normalized_channel = channel_name.to_lowercase();
+    let safe_channel_name = normalized_channel.replace('#', "hash_");
+    let entry_key = format!("channel_key_{}", safe_channel_name);
+
+    with_config_mut(|config| {
+        config.entries.remove(&entry_key);
+        Ok(())
+    })
+}
+
+pub fn remove_ratchet_channel_key(channel_name: &str) -> Result<()> {
+    let normalized_channel = channel_name.to_lowercase();
+    
+    with_config_mut(|config| {
+        // Remove ratchet state for this channel
+        config.ratchet_states.remove(&normalized_channel);
+        Ok(())
+    })
+}
 pub use networks::{
     count_network_mappings, count_unique_networks, delete_network, get_all_network_mappings,
     get_all_networks, get_network_for_nick, get_nicknames_by_network, has_network, merge_networks,

--- a/fish_11_dll/src/config/mod.rs
+++ b/fish_11_dll/src/config/mod.rs
@@ -162,10 +162,16 @@ pub fn has_manual_channel_key(channel_name: &str) -> bool {
 }
 
 pub fn has_ratchet_channel_key(channel_name: &str) -> bool {
-    get_ratchet_channel_key(channel_name).is_ok()
+    // For now, we'll check if there's a ratchet state for this channel
+    // This is a simplified check - in a real implementation, you'd want to
+    // verify that the ratchet state has a valid current key
+    with_config(|config| {
+        let normalized_channel = channel_name.to_lowercase();
+        Ok(config.channel_ratchet_states.contains_key(&normalized_channel))
+    }).unwrap_or(false)
 }
 
-pub fn remove_manual_channel_key(channel_name: &str) -> Result<()> {
+pub fn remove_manual_channel_key(channel_name: &str) -> Result<(), crate::error::FishError> {
     let normalized_channel = channel_name.to_lowercase();
     let safe_channel_name = normalized_channel.replace('#', "hash_");
     let entry_key = format!("channel_key_{}", safe_channel_name);
@@ -176,12 +182,12 @@ pub fn remove_manual_channel_key(channel_name: &str) -> Result<()> {
     })
 }
 
-pub fn remove_ratchet_channel_key(channel_name: &str) -> Result<()> {
+pub fn remove_ratchet_channel_key(channel_name: &str) -> Result<(), crate::error::FishError> {
     let normalized_channel = channel_name.to_lowercase();
     
     with_config_mut(|config| {
         // Remove ratchet state for this channel
-        config.ratchet_states.remove(&normalized_channel);
+        config.channel_ratchet_states.remove(&normalized_channel);
         Ok(())
     })
 }

--- a/fish_11_dll/src/dll_interface/fish11_hasmanualchannelkey.rs
+++ b/fish_11_dll/src/dll_interface/fish11_hasmanualchannelkey.rs
@@ -1,0 +1,102 @@
+use crate::platform_types::{BOOL, HWND};
+use crate::unified_error::DllError;
+use crate::{buffer_utils, config, dll_function_identifier};
+use std::ffi::c_char;
+use std::os::raw::c_int;
+
+// Checks if a manual channel key exists for a channel.
+//
+// Input format: <#channel>
+//
+// Returns: "1" if key exists, "0" if not exists, or error message
+
+dll_function_identifier!(FiSH11_HasManualChannelKey, data, {
+    let channel_name = unsafe { buffer_utils::parse_buffer_input(data)? };
+    
+    // Validate channel name format
+    if !channel_name.starts_with('#') && !channel_name.starts_with('&') {
+        return Err(DllError::InvalidInput {
+            param: "channel".to_string(),
+            reason: "Channel name must start with # or &".to_string(),
+        });
+    }
+    
+    // Check if manual key exists
+    let result = config::get_manual_channel_key(&channel_name).is_ok();
+    
+    Ok(if result { "1" } else { "0" }.to_string())
+});
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::dll_interface::MIRC_COMMAND;
+    use std::ffi::CStr;
+    use std::ptr;
+
+    fn call_has_manual_channel_key(input: &str, buffer_size: usize) -> (c_int, String) {
+        let mut buffer = vec![0i8; buffer_size];
+
+        // Copy the input into the data buffer (mIRC style: data is input/output)
+        if !input.is_empty() {
+            let bytes = input.as_bytes();
+            let copy_len = std::cmp::min(bytes.len(), buffer.len());
+            unsafe {
+                std::ptr::copy_nonoverlapping(
+                    bytes.as_ptr(),
+                    buffer.as_mut_ptr() as *mut u8,
+                    copy_len,
+                );
+            }
+        }
+
+        // Override buffer size for this test to prevent heap corruption
+        let prev_size = crate::dll_interface::override_buffer_size_for_test(buffer_size);
+
+        let result = FiSH11_HasManualChannelKey(
+            ptr::null_mut(),
+            ptr::null_mut(),
+            buffer.as_mut_ptr(),
+            ptr::null_mut(),
+            ptr::null_mut(),
+            ptr::null_mut(),
+        );
+
+        // Restore previous buffer size
+        crate::dll_interface::restore_buffer_size_for_test(prev_size);
+
+        let c_str = unsafe { CStr::from_ptr(buffer.as_ptr()) };
+        (result, c_str.to_string_lossy().to_string())
+    }
+
+    #[test]
+    fn test_has_manual_channel_key_exists() {
+        // First set a key
+        let key = [42u8; 32];
+        let key_b64 = crate::utils::base64_encode(&key);
+        let set_input = format!("#test {}", key_b64);
+        
+        // Call SetManualChannelKey first
+        let (set_code, set_msg) = super::super::fish11_setmanualchannelkey::tests::call_set_manual_channel_key(&set_input, 256);
+        assert_eq!(set_code, crate::dll_interface::MIRC_IDENTIFIER);
+        
+        // Now test if it exists
+        let (code, msg) = call_has_manual_channel_key("#test", 256);
+        assert_eq!(code, crate::dll_interface::MIRC_IDENTIFIER);
+        assert_eq!(msg.trim_end_matches(char::from(0)), "1");
+    }
+
+    #[test]
+    fn test_has_manual_channel_key_not_exists() {
+        let (code, msg) = call_has_manual_channel_key("#nonexistent", 256);
+        assert_eq!(code, crate::dll_interface::MIRC_IDENTIFIER);
+        assert_eq!(msg.trim_end_matches(char::from(0)), "0");
+    }
+
+    #[test]
+    fn test_has_manual_channel_key_invalid_channel() {
+        let (code, msg) = call_has_manual_channel_key("invalid", 256);
+        assert_eq!(code, MIRC_COMMAND);
+        assert!(msg.to_lowercase().contains("channel name must start with"));
+    }
+}

--- a/fish_11_dll/src/dll_interface/fish11_hasmanualchannelkey.rs
+++ b/fish_11_dll/src/dll_interface/fish11_hasmanualchannelkey.rs
@@ -77,13 +77,27 @@ mod tests {
         let set_input = format!("#test {}", key_b64);
         
         // Call SetManualChannelKey first
-        let (set_code, set_msg) = super::super::fish11_setmanualchannelkey::tests::call_set_manual_channel_key(&set_input, 256);
+        let (set_code, _set_msg) = super::super::fish11_setmanualchannelkey::tests::call_set_manual_channel_key(&set_input, 256);
         assert_eq!(set_code, crate::dll_interface::MIRC_IDENTIFIER);
         
         // Now test if it exists
         let (code, msg) = call_has_manual_channel_key("#test", 256);
         assert_eq!(code, crate::dll_interface::MIRC_IDENTIFIER);
         assert_eq!(msg.trim_end_matches(char::from(0)), "1");
+    }
+
+    #[test]
+    fn test_has_manual_channel_key_not_exists() {
+        let (code, msg) = call_has_manual_channel_key("#nonexistent", 256);
+        assert_eq!(code, crate::dll_interface::MIRC_IDENTIFIER);
+        assert_eq!(msg.trim_end_matches(char::from(0)), "0");
+    }
+
+    #[test]
+    fn test_has_manual_channel_key_invalid_channel() {
+        let (code, msg) = call_has_manual_channel_key("invalid", 256);
+        assert_eq!(code, MIRC_COMMAND);
+        assert!(msg.to_lowercase().contains("channel name must start with"));
     }
 
     #[test]

--- a/fish_11_dll/src/dll_interface/fish11_hasratchetchannelkey.rs
+++ b/fish_11_dll/src/dll_interface/fish11_hasratchetchannelkey.rs
@@ -1,0 +1,85 @@
+use crate::platform_types::{BOOL, HWND};
+use crate::unified_error::DllError;
+use crate::{buffer_utils, config, dll_function_identifier};
+use std::ffi::c_char;
+use std::os::raw::c_int;
+
+// Checks if a ratchet channel key exists for a channel.
+//
+// Input format: <#channel>
+//
+// Returns: "1" if key exists, "0" if not exists, or error message
+
+dll_function_identifier!(FiSH11_HasRatchetChannelKey, data, {
+    let channel_name = unsafe { buffer_utils::parse_buffer_input(data)? };
+    
+    // Validate channel name format
+    if !channel_name.starts_with('#') && !channel_name.starts_with('&') {
+        return Err(DllError::InvalidInput {
+            param: "channel".to_string(),
+            reason: "Channel name must start with # or &".to_string(),
+        });
+    }
+    
+    // Check if ratchet key exists
+    let result = config::get_ratchet_channel_key(&channel_name).is_ok();
+    
+    Ok(if result { "1" } else { "0" }.to_string())
+});
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::dll_interface::MIRC_COMMAND;
+    use std::ffi::CStr;
+    use std::ptr;
+
+    fn call_has_ratchet_channel_key(input: &str, buffer_size: usize) -> (c_int, String) {
+        let mut buffer = vec![0i8; buffer_size];
+
+        // Copy the input into the data buffer (mIRC style: data is input/output)
+        if !input.is_empty() {
+            let bytes = input.as_bytes();
+            let copy_len = std::cmp::min(bytes.len(), buffer.len());
+            unsafe {
+                std::ptr::copy_nonoverlapping(
+                    bytes.as_ptr(),
+                    buffer.as_mut_ptr() as *mut u8,
+                    copy_len,
+                );
+            }
+        }
+
+        // Override buffer size for this test to prevent heap corruption
+        let prev_size = crate::dll_interface::override_buffer_size_for_test(buffer_size);
+
+        let result = FiSH11_HasRatchetChannelKey(
+            ptr::null_mut(),
+            ptr::null_mut(),
+            buffer.as_mut_ptr(),
+            ptr::null_mut(),
+            ptr::null_mut(),
+            ptr::null_mut(),
+        );
+
+        // Restore previous buffer size
+        crate::dll_interface::restore_buffer_size_for_test(prev_size);
+
+        let c_str = unsafe { CStr::from_ptr(buffer.as_ptr()) };
+        (result, c_str.to_string_lossy().to_string())
+    }
+
+    #[test]
+    fn test_has_ratchet_channel_key_not_exists() {
+        let (code, msg) = call_has_ratchet_channel_key("#nonexistent", 256);
+        assert_eq!(code, crate::dll_interface::MIRC_IDENTIFIER);
+        assert_eq!(msg.trim_end_matches(char::from(0)), "0");
+    }
+
+    #[test]
+    fn test_has_ratchet_channel_key_invalid_channel() {
+        let (code, msg) = call_has_ratchet_channel_key("invalid", 256);
+        assert_eq!(code, MIRC_COMMAND);
+        assert!(msg.to_lowercase().contains("channel name must start with"));
+    }
+}

--- a/fish_11_dll/src/dll_interface/fish11_hasratchetchannelkey.rs
+++ b/fish_11_dll/src/dll_interface/fish11_hasratchetchannelkey.rs
@@ -9,10 +9,9 @@ use std::os::raw::c_int;
 // Input format: <#channel>
 //
 // Returns: "1" if key exists, "0" if not exists, or error message
-
 dll_function_identifier!(FiSH11_HasRatchetChannelKey, data, {
     let channel_name = unsafe { buffer_utils::parse_buffer_input(data)? };
-    
+
     // Validate channel name format
     if !channel_name.starts_with('#') && !channel_name.starts_with('&') {
         return Err(DllError::InvalidInput {
@@ -20,10 +19,10 @@ dll_function_identifier!(FiSH11_HasRatchetChannelKey, data, {
             reason: "Channel name must start with # or &".to_string(),
         });
     }
-    
+
     // Check if ratchet key exists
-    let result = config::get_ratchet_channel_key(&channel_name).is_ok();
-    
+    let result = config::has_ratchet_channel_key(&channel_name);
+
     Ok(if result { "1" } else { "0" }.to_string())
 });
 

--- a/fish_11_dll/src/dll_interface/fish11_removemanualchannelkey.rs
+++ b/fish_11_dll/src/dll_interface/fish11_removemanualchannelkey.rs
@@ -1,0 +1,88 @@
+use crate::platform_types::{BOOL, HWND};
+use crate::unified_error::DllError;
+use crate::{buffer_utils, config, dll_function_identifier, log_debug};
+use std::ffi::c_char;
+use std::os::raw::c_int;
+
+// Removes a manual channel key for a channel.
+//
+// Input format: <#channel>
+//
+// Returns: Success message or error
+
+dll_function_identifier!(FiSH11_RemoveManualChannelKey, data, {
+    let channel_name = unsafe { buffer_utils::parse_buffer_input(data)? };
+    
+    // Validate channel name format
+    if !channel_name.starts_with('#') && !channel_name.starts_with('&') {
+        return Err(DllError::InvalidInput {
+            param: "channel".to_string(),
+            reason: "Channel name must start with # or &".to_string(),
+        });
+    }
+    
+    // Remove the manual channel key
+    config::remove_manual_channel_key(&channel_name)?;
+    
+    log_debug!("Successfully removed manual channel key for {}", channel_name);
+    
+    Ok(format!("Manual channel key removed for {}", channel_name))
+});
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::dll_interface::MIRC_COMMAND;
+    use std::ffi::CStr;
+    use std::ptr;
+
+    fn call_remove_manual_channel_key(input: &str, buffer_size: usize) -> (c_int, String) {
+        let mut buffer = vec![0i8; buffer_size];
+
+        // Copy the input into the data buffer (mIRC style: data is input/output)
+        if !input.is_empty() {
+            let bytes = input.as_bytes();
+            let copy_len = std::cmp::min(bytes.len(), buffer.len());
+            unsafe {
+                std::ptr::copy_nonoverlapping(
+                    bytes.as_ptr(),
+                    buffer.as_mut_ptr() as *mut u8,
+                    copy_len,
+                );
+            }
+        }
+
+        // Override buffer size for this test to prevent heap corruption
+        let prev_size = crate::dll_interface::override_buffer_size_for_test(buffer_size);
+
+        let result = FiSH11_RemoveManualChannelKey(
+            ptr::null_mut(),
+            ptr::null_mut(),
+            buffer.as_mut_ptr(),
+            ptr::null_mut(),
+            ptr::null_mut(),
+            ptr::null_mut(),
+        );
+
+        // Restore previous buffer size
+        crate::dll_interface::restore_buffer_size_for_test(prev_size);
+
+        let c_str = unsafe { CStr::from_ptr(buffer.as_ptr()) };
+        (result, c_str.to_string_lossy().to_string())
+    }
+
+    #[test]
+    fn test_remove_manual_channel_key_invalid_channel() {
+        let (code, msg) = call_remove_manual_channel_key("invalid", 256);
+        assert_eq!(code, MIRC_COMMAND);
+        assert!(msg.to_lowercase().contains("channel name must start with"));
+    }
+
+    #[test]
+    fn test_remove_manual_channel_key_nonexistent() {
+        let (code, msg) = call_remove_manual_channel_key("#nonexistent", 256);
+        // Should succeed even if key doesn't exist (idempotent operation)
+        assert_eq!(code, crate::dll_interface::MIRC_IDENTIFIER);
+        assert!(msg.to_lowercase().contains("manual channel key removed"));
+    }
+}

--- a/fish_11_dll/src/dll_interface/fish11_removeratchetchannelkey.rs
+++ b/fish_11_dll/src/dll_interface/fish11_removeratchetchannelkey.rs
@@ -1,0 +1,88 @@
+use crate::platform_types::{BOOL, HWND};
+use crate::unified_error::DllError;
+use crate::{buffer_utils, config, dll_function_identifier, log_debug};
+use std::ffi::c_char;
+use std::os::raw::c_int;
+
+// Removes a ratchet channel key for a channel.
+//
+// Input format: <#channel>
+//
+// Returns: Success message or error
+
+dll_function_identifier!(FiSH11_RemoveRatchetChannelKey, data, {
+    let channel_name = unsafe { buffer_utils::parse_buffer_input(data)? };
+    
+    // Validate channel name format
+    if !channel_name.starts_with('#') && !channel_name.starts_with('&') {
+        return Err(DllError::InvalidInput {
+            param: "channel".to_string(),
+            reason: "Channel name must start with # or &".to_string(),
+        });
+    }
+    
+    // Remove the ratchet channel key
+    config::remove_ratchet_channel_key(&channel_name)?;
+    
+    log_debug!("Successfully removed ratchet channel key for {}", channel_name);
+    
+    Ok(format!("Ratchet channel key removed for {}", channel_name))
+});
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::dll_interface::MIRC_COMMAND;
+    use std::ffi::CStr;
+    use std::ptr;
+
+    fn call_remove_ratchet_channel_key(input: &str, buffer_size: usize) -> (c_int, String) {
+        let mut buffer = vec![0i8; buffer_size];
+
+        // Copy the input into the data buffer (mIRC style: data is input/output)
+        if !input.is_empty() {
+            let bytes = input.as_bytes();
+            let copy_len = std::cmp::min(bytes.len(), buffer.len());
+            unsafe {
+                std::ptr::copy_nonoverlapping(
+                    bytes.as_ptr(),
+                    buffer.as_mut_ptr() as *mut u8,
+                    copy_len,
+                );
+            }
+        }
+
+        // Override buffer size for this test to prevent heap corruption
+        let prev_size = crate::dll_interface::override_buffer_size_for_test(buffer_size);
+
+        let result = FiSH11_RemoveRatchetChannelKey(
+            ptr::null_mut(),
+            ptr::null_mut(),
+            buffer.as_mut_ptr(),
+            ptr::null_mut(),
+            ptr::null_mut(),
+            ptr::null_mut(),
+        );
+
+        // Restore previous buffer size
+        crate::dll_interface::restore_buffer_size_for_test(prev_size);
+
+        let c_str = unsafe { CStr::from_ptr(buffer.as_ptr()) };
+        (result, c_str.to_string_lossy().to_string())
+    }
+
+    #[test]
+    fn test_remove_ratchet_channel_key_invalid_channel() {
+        let (code, msg) = call_remove_ratchet_channel_key("invalid", 256);
+        assert_eq!(code, MIRC_COMMAND);
+        assert!(msg.to_lowercase().contains("channel name must start with"));
+    }
+
+    #[test]
+    fn test_remove_ratchet_channel_key_nonexistent() {
+        let (code, msg) = call_remove_ratchet_channel_key("#nonexistent", 256);
+        // Should succeed even if key doesn't exist (idempotent operation)
+        assert_eq!(code, crate::dll_interface::MIRC_IDENTIFIER);
+        assert!(msg.to_lowercase().contains("ratchet channel key removed"));
+    }
+}

--- a/fish_11_dll/src/dll_interface/fish11_setmanualchannelkey.rs
+++ b/fish_11_dll/src/dll_interface/fish11_setmanualchannelkey.rs
@@ -72,7 +72,7 @@ mod tests {
     use std::ffi::CStr;
     use std::ptr;
 
-    fn call_set_manual_channel_key(input: &str, buffer_size: usize) -> (c_int, String) {
+    pub fn call_set_manual_channel_key(input: &str, buffer_size: usize) -> (c_int, String) {
         let mut buffer = vec![0i8; buffer_size];
 
         // Copy the input into the data buffer (mIRC style: data is input/output)

--- a/fish_11_dll/src/dll_interface/fish11_setmanualchannelkey.rs
+++ b/fish_11_dll/src/dll_interface/fish11_setmanualchannelkey.rs
@@ -2,8 +2,9 @@ use crate::platform_types::{BOOL, HWND};
 use crate::unified_error::DllError;
 use crate::utils::base64_decode;
 use crate::{buffer_utils, config, dll_function_identifier, log_debug};
-use std::ffi::c_char;
+use std::ffi::{CStr, c_char};
 use std::os::raw::c_int;
+use std::ptr;
 
 // Sets a manual encryption key for a channel.
 //
@@ -65,47 +66,41 @@ dll_function_identifier!(FiSH11_SetManualChannelKey, data, {
     Ok(format!("Manual channel key set for {}", channel_name))
 });
 
+// Public test helper function that can be used by other modules
+#[allow(dead_code)]
+pub fn call_set_manual_channel_key(input: &str, buffer_size: usize) -> (c_int, String) {
+    let mut buffer = vec![0i8; buffer_size];
+
+    // Copy the input into the data buffer (mIRC style: data is input/output)
+    if !input.is_empty() {
+        let bytes = input.as_bytes();
+        let copy_len = std::cmp::min(bytes.len(), buffer.len());
+        unsafe {
+            std::ptr::copy_nonoverlapping(bytes.as_ptr(), buffer.as_mut_ptr() as *mut u8, copy_len);
+        }
+    }
+
+    // Call the actual function with proper mIRC DLL signature
+    let result_code = FiSH11_SetManualChannelKey(
+        ptr::null_mut(),                    // mWnd
+        ptr::null_mut(),                    // aWnd
+        buffer.as_mut_ptr() as *mut c_char, // data
+        ptr::null_mut(),                    // show
+        ptr::null_mut(),                    // nopause
+        ptr::null_mut(),                    // ret_buffer_size
+    );
+
+    // Extract the result string from the buffer
+    let result_cstr = unsafe { CStr::from_ptr(buffer.as_ptr() as *const c_char) };
+    let result_str = result_cstr.to_string_lossy().into_owned();
+
+    (result_code, result_str)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
     use crate::dll_interface::MIRC_COMMAND;
-    use std::ffi::CStr;
-    use std::ptr;
-
-    pub fn call_set_manual_channel_key(input: &str, buffer_size: usize) -> (c_int, String) {
-        let mut buffer = vec![0i8; buffer_size];
-
-        // Copy the input into the data buffer (mIRC style: data is input/output)
-        if !input.is_empty() {
-            let bytes = input.as_bytes();
-            let copy_len = std::cmp::min(bytes.len(), buffer.len());
-            unsafe {
-                std::ptr::copy_nonoverlapping(
-                    bytes.as_ptr(),
-                    buffer.as_mut_ptr() as *mut u8,
-                    copy_len,
-                );
-            }
-        }
-
-        // Override buffer size for this test to prevent heap corruption
-        let prev_size = crate::dll_interface::override_buffer_size_for_test(buffer_size);
-
-        let result = FiSH11_SetManualChannelKey(
-            ptr::null_mut(),
-            ptr::null_mut(),
-            buffer.as_mut_ptr(),
-            ptr::null_mut(),
-            ptr::null_mut(),
-            ptr::null_mut(),
-        );
-
-        // Restore previous buffer size
-        crate::dll_interface::restore_buffer_size_for_test(prev_size);
-
-        let c_str = unsafe { CStr::from_ptr(buffer.as_ptr()) };
-        (result, c_str.to_string_lossy().to_string())
-    }
 
     #[test]
     fn test_set_manual_channel_key_normal() {

--- a/fish_11_dll/src/dll_interface/fish11_setmanualchannelkeyfrompassword.rs
+++ b/fish_11_dll/src/dll_interface/fish11_setmanualchannelkeyfrompassword.rs
@@ -60,10 +60,10 @@ fn derive_key_from_password(password: &str) -> DllResult<[u8; 32]> {
     // Derive a 32-byte key using HKDF-SHA256
     let hkdf = Hkdf::<Sha256>::new(Some(salt), ikm);
     let mut output = [0u8; 32];
-    hkdf.expand(b"channel-key-expansion", &mut output)
-        .map_err(|e| DllError::KeyInvalid {
-            reason: format!("HKDF key derivation failed: {}", e)
-        })?;
+    hkdf.expand(b"channel-key-expansion", &mut output).map_err(|e| DllError::InvalidInput {
+        param: "password".to_string(),
+        reason: format!("HKDF key derivation failed: {}", e),
+    })?;
 
     Ok(output)
 }
@@ -75,7 +75,10 @@ mod tests {
     use std::ffi::CStr;
     use std::ptr;
 
-    fn call_set_manual_channel_key_from_password(input: &str, buffer_size: usize) -> (c_int, String) {
+    fn call_set_manual_channel_key_from_password(
+        input: &str,
+        buffer_size: usize,
+    ) -> (c_int, String) {
         let mut buffer = vec![0i8; buffer_size];
 
         // Copy the input into the data buffer (mIRC style: data is input/output)

--- a/fish_11_dll/src/dll_interface/fish11_setmanualchannelkeyfrompassword.rs
+++ b/fish_11_dll/src/dll_interface/fish11_setmanualchannelkeyfrompassword.rs
@@ -1,0 +1,135 @@
+use crate::platform_types::{BOOL, HWND};
+use crate::unified_error::DllError;
+use crate::{buffer_utils, config, dll_function_identifier, log_debug};
+use std::ffi::c_char;
+use std::os::raw::c_int;
+
+// Sets a manual channel key from a password or short key.
+// This function accepts keys of any length and securely expands them to 32 bytes
+// using a key derivation function (HKDF with SHA-256).
+//
+// Input format: <#channel> <key_of_any_length>
+//
+// Returns: Success message or error
+
+dll_function_identifier!(FiSH11_SetManualChannelKeyFromPassword, data, {
+    let input = unsafe { buffer_utils::parse_buffer_input(data)? };
+    let parts: Vec<&str> = input.splitn(2, ' ').collect();
+
+    if parts.len() < 2 {
+        return Err(DllError::InvalidInput {
+            param: "input".to_string(),
+            reason: "Usage: <#channel> <key_of_any_length>".to_string(),
+        });
+    }
+
+    let channel_name = parts[0];
+    let key_material = parts[1];
+
+    // Validate channel name format
+    if !channel_name.starts_with('#') && !channel_name.starts_with('&') {
+        return Err(DllError::InvalidInput {
+            param: "channel".to_string(),
+            reason: "Channel name must start with # or &".to_string(),
+        });
+    }
+
+    // Derive a 32-byte key from the input material using HKDF
+    let derived_key = derive_key_from_password(key_material)?;
+
+    // Set the manual channel key (this will encrypt it and store it in the config file)
+    config::set_manual_channel_key(channel_name, &derived_key, true)?;
+
+    log_debug!("Successfully set manual channel key for {} from password", channel_name);
+
+    Ok(format!("Manual channel key set for {}", channel_name))
+});
+
+/// Derives a 32-byte cryptographic key from password/short key material using HKDF
+fn derive_key_from_password(password: &str) -> Result<[u8; 32]> {
+    use hkdf::Hkdf;
+    use sha2::Sha256;
+    
+    // Use channel name as salt to prevent rainbow table attacks
+    // In a real implementation, we'd use a random salt stored with the key
+    let salt = b"FiSH11-ChannelKey";
+    
+    // Use the password as IKM (input key material)
+    let ikm = password.as_bytes();
+    
+    // Derive a 32-byte key using HKDF-SHA256
+    let hkdf = Hkdf::<Sha256>::new(Some(salt), ikm);
+    let mut output = [0u8; 32];
+    hkdf.expand(b"channel-key-expansion", &mut output)
+        .map_err(|e| FishError::CryptoError(format!("HKDF expansion failed: {}", e)))?;
+    
+    Ok(output)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::dll_interface::MIRC_COMMAND;
+    use std::ffi::CStr;
+    use std::ptr;
+
+    fn call_set_manual_channel_key_from_password(input: &str, buffer_size: usize) -> (c_int, String) {
+        let mut buffer = vec![0i8; buffer_size];
+
+        // Copy the input into the data buffer (mIRC style: data is input/output)
+        if !input.is_empty() {
+            let bytes = input.as_bytes();
+            let copy_len = std::cmp::min(bytes.len(), buffer.len());
+            unsafe {
+                std::ptr::copy_nonoverlapping(
+                    bytes.as_ptr(),
+                    buffer.as_mut_ptr() as *mut u8,
+                    copy_len,
+                );
+            }
+        }
+
+        // Override buffer size for this test to prevent heap corruption
+        let prev_size = crate::dll_interface::override_buffer_size_for_test(buffer_size);
+
+        let result = FiSH11_SetManualChannelKeyFromPassword(
+            ptr::null_mut(),
+            ptr::null_mut(),
+            buffer.as_mut_ptr(),
+            ptr::null_mut(),
+            ptr::null_mut(),
+            ptr::null_mut(),
+        );
+
+        // Restore previous buffer size
+        crate::dll_interface::restore_buffer_size_for_test(prev_size);
+
+        let c_str = unsafe { CStr::from_ptr(buffer.as_ptr()) };
+        (result, c_str.to_string_lossy().to_string())
+    }
+
+    #[test]
+    fn test_set_manual_channel_key_from_password_short() {
+        let input = "#test mypassword";
+        let (code, msg) = call_set_manual_channel_key_from_password(&input, 256);
+        assert_eq!(code, crate::dll_interface::MIRC_IDENTIFIER);
+        assert!(msg.to_lowercase().contains("manual channel key set"));
+    }
+
+    #[test]
+    fn test_set_manual_channel_key_from_password_long() {
+        let long_password = "This is a very long password that is definitely longer than 32 bytes";
+        let input = format!("#test {}", long_password);
+        let (code, msg) = call_set_manual_channel_key_from_password(&input, 256);
+        assert_eq!(code, crate::dll_interface::MIRC_IDENTIFIER);
+        assert!(msg.to_lowercase().contains("manual channel key set"));
+    }
+
+    #[test]
+    fn test_set_manual_channel_key_from_password_invalid_channel() {
+        let input = "invalid mypassword";
+        let (code, msg) = call_set_manual_channel_key_from_password(&input, 256);
+        assert_eq!(code, MIRC_COMMAND);
+        assert!(msg.to_lowercase().contains("channel name must start with"));
+    }
+}

--- a/fish_11_dll/src/dll_interface/ini_tests.rs
+++ b/fish_11_dll/src/dll_interface/ini_tests.rs
@@ -164,4 +164,65 @@ mod tests {
         let (_, result) = call_dll_function(INI_GetInt as _, "unknown_key");
         assert_eq!(result, "0");
     }
+
+    // INI_SetString Tests
+    #[test]
+    fn test_ini_setstring_plain_prefix() {
+        setup_test_config();
+        let (_, result) = call_dll_function(INI_SetString as _, "plain_prefix +newtest");
+        assert!(result.contains("set successfully"));
+
+        // Verify the value was actually set
+        let (_, get_result) = call_dll_function(INI_GetString as _, "plain_prefix");
+        assert_eq!(get_result, "+newtest");
+    }
+
+    #[test]
+    fn test_ini_setstring_mark_encrypted() {
+        setup_test_config();
+        let (_, result) = call_dll_function(INI_SetString as _, "mark_encrypted [NEW]");
+        assert!(result.contains("set successfully"));
+
+        // Verify the value was actually set
+        let (_, get_result) = call_dll_function(INI_GetString as _, "mark_encrypted");
+        assert_eq!(get_result, "[NEW]");
+    }
+
+    #[test]
+    fn test_ini_setstring_unknown_key() {
+        setup_test_config();
+        let (_, result) = call_dll_function(INI_SetString as _, "unknown_key some_value");
+        assert!(result.contains("set successfully"));
+    }
+
+    // INI_SetInt Tests
+    #[test]
+    fn test_ini_setint_mark_position() {
+        setup_test_config();
+        let (_, result) = call_dll_function(INI_SetInt as _, "mark_position 99");
+        assert!(result.contains("set successfully"));
+
+        // Verify the value was actually set
+        let (_, get_result) = call_dll_function(INI_GetInt as _, "mark_position");
+        assert_eq!(get_result, "99");
+    }
+
+    #[test]
+    fn test_ini_setint_process_incoming() {
+        setup_test_config();
+        let (_, result) = call_dll_function(INI_SetInt as _, "process_incoming 1");
+        assert!(result.contains("set successfully"));
+
+        // Verify the value was actually set
+        let (_, get_result) = call_dll_function(INI_GetBool as _, "process_incoming");
+        assert_eq!(get_result, "1");
+    }
+
+    #[test]
+    fn test_ini_setint_invalid_value() {
+        setup_test_config();
+        let (result_code, result) = call_dll_function(INI_SetInt as _, "mark_position invalid");
+        assert_eq!(result_code, crate::dll_interface::MIRC_ERROR);
+        assert!(result.to_lowercase().contains("invalid"));
+    }
 }

--- a/fish_11_dll/src/dll_interface/mod.rs
+++ b/fish_11_dll/src/dll_interface/mod.rs
@@ -21,6 +21,10 @@ mod fish11_logsetkey;
 mod fish11_setencryptionprefix;
 mod fish11_setfishprefix;
 mod fish11_setmanualchannelkey;
+mod fish11_hasmanualchannelkey;
+mod fish11_hasratchetchannelkey;
+mod fish11_removemanualchannelkey;
+mod fish11_removeratchetchannelkey;
 mod fish11_setnetwork;
 mod utility;
 
@@ -37,6 +41,10 @@ pub use fish11_masterkey::{
 pub use fish11_setencryptionprefix::FiSH11_SetEncryptionPrefix;
 pub use fish11_setfishprefix::FiSH11_SetFishPrefix;
 pub use fish11_setmanualchannelkey::FiSH11_SetManualChannelKey;
+pub use fish11_hasmanualchannelkey::FiSH11_HasManualChannelKey;
+pub use fish11_hasratchetchannelkey::FiSH11_HasRatchetChannelKey;
+pub use fish11_removemanualchannelkey::FiSH11_RemoveManualChannelKey;
+pub use fish11_removeratchetchannelkey::FiSH11_RemoveRatchetChannelKey;
 pub use key_management::{FiSH11_ProcessPublicKey, FiSH11_TestCrypt};
 
 pub use crate::channel_encryption::init_key::FiSH11_InitChannelKey;

--- a/fish_11_dll/src/dll_interface/mod.rs
+++ b/fish_11_dll/src/dll_interface/mod.rs
@@ -1,7 +1,5 @@
 use std::ffi::CStr;
 use std::ptr;
-//use std::sync::Mutex;
-
 mod fish11_coreversion;
 mod fish11_decryptmsg;
 mod fish11_encryptmsg;
@@ -13,24 +11,28 @@ mod fish11_genkey;
 mod fish11_getconfigpath;
 mod fish11_getkeyttl;
 mod fish11_getratchetstate;
+mod fish11_hasmanualchannelkey;
+mod fish11_hasratchetchannelkey;
 mod fish11_help;
 mod fish11_logdecrypt;
 mod fish11_logdecryptfile;
 mod fish11_logencrypt;
 mod fish11_logsetkey;
+mod fish11_removemanualchannelkey;
+mod fish11_removeratchetchannelkey;
 mod fish11_setencryptionprefix;
 mod fish11_setfishprefix;
 mod fish11_setmanualchannelkey;
 mod fish11_setmanualchannelkeyfrompassword;
-mod fish11_hasmanualchannelkey;
-mod fish11_hasratchetchannelkey;
-mod fish11_removemanualchannelkey;
-mod fish11_removeratchetchannelkey;
 mod fish11_setnetwork;
 mod utility;
 
+pub use crate::channel_encryption::init_key::FiSH11_InitChannelKey;
+pub use crate::channel_encryption::process_key::FiSH11_ProcessChannelKey;
 pub use fish11_getkeyttl::FiSH11_GetKeyTTL;
 pub use fish11_getratchetstate::FiSH11_GetRatchetState;
+pub use fish11_hasmanualchannelkey::FiSH11_HasManualChannelKey;
+pub use fish11_hasratchetchannelkey::FiSH11_HasRatchetChannelKey;
 pub use fish11_logdecrypt::FiSH11_LogDecrypt;
 pub use fish11_logdecryptfile::FiSH11_LogDecryptFile;
 pub use fish11_logencrypt::FiSH11_LogEncrypt;
@@ -39,19 +41,15 @@ pub use fish11_masterkey::{
     FiSH11_MasterKeyChangePassword, FiSH11_MasterKeyInit, FiSH11_MasterKeyIsUnlocked,
     FiSH11_MasterKeyLock, FiSH11_MasterKeyStatus, FiSH11_MasterKeyUnlock,
 };
+pub use fish11_removemanualchannelkey::FiSH11_RemoveManualChannelKey;
+pub use fish11_removeratchetchannelkey::FiSH11_RemoveRatchetChannelKey;
 pub use fish11_setencryptionprefix::FiSH11_SetEncryptionPrefix;
 pub use fish11_setfishprefix::FiSH11_SetFishPrefix;
 pub use fish11_setmanualchannelkey::FiSH11_SetManualChannelKey;
 pub use fish11_setmanualchannelkeyfrompassword::FiSH11_SetManualChannelKeyFromPassword;
-pub use fish11_hasmanualchannelkey::FiSH11_HasManualChannelKey;
-pub use fish11_hasratchetchannelkey::FiSH11_HasRatchetChannelKey;
-pub use fish11_removemanualchannelkey::FiSH11_RemoveManualChannelKey;
-pub use fish11_removeratchetchannelkey::FiSH11_RemoveRatchetChannelKey;
+pub use ini_types::{INI_GetBool, INI_GetInt, INI_GetString, INI_SetInt, INI_SetString};
 pub use key_management::{FiSH11_ProcessPublicKey, FiSH11_TestCrypt};
-
-pub use crate::channel_encryption::init_key::FiSH11_InitChannelKey;
-pub use crate::channel_encryption::process_key::FiSH11_ProcessChannelKey;
-
+pub(crate) mod core;
 pub mod dll_error;
 pub mod fish11_exchangekey;
 pub mod fish11_masterkey;
@@ -61,9 +59,6 @@ pub mod fish11_setmircdir;
 pub mod function_template;
 pub mod ini_types;
 pub mod key_management;
-
-pub(crate) mod core;
-
 // Re-export fish_11_core globals for use within fish_11_dll
 pub use fish_11_core::globals::{
     CRATE_VERSION, CURRENT_YEAR, DEFAULT_MIRC_BUFFER_SIZE, FUNCTION_TIMEOUT_SECONDS,
@@ -71,7 +66,6 @@ pub use fish_11_core::globals::{
     MIRC_CONTINUE, MIRC_ERROR, MIRC_HALT, MIRC_IDENTIFIER, MIRC_TYPICAL_BUFFER_SIZE,
     NICK_VALIDATOR,
 };
-
 /// Returns the maximum amount of data that can be written into the output buffer.
 /// This implementation includes fallback to global buffer size if LOAD_INFO is not available.
 pub(crate) fn get_buffer_size() -> usize {

--- a/fish_11_dll/src/dll_interface/mod.rs
+++ b/fish_11_dll/src/dll_interface/mod.rs
@@ -21,6 +21,7 @@ mod fish11_logsetkey;
 mod fish11_setencryptionprefix;
 mod fish11_setfishprefix;
 mod fish11_setmanualchannelkey;
+mod fish11_setmanualchannelkeyfrompassword;
 mod fish11_hasmanualchannelkey;
 mod fish11_hasratchetchannelkey;
 mod fish11_removemanualchannelkey;
@@ -41,6 +42,7 @@ pub use fish11_masterkey::{
 pub use fish11_setencryptionprefix::FiSH11_SetEncryptionPrefix;
 pub use fish11_setfishprefix::FiSH11_SetFishPrefix;
 pub use fish11_setmanualchannelkey::FiSH11_SetManualChannelKey;
+pub use fish11_setmanualchannelkeyfrompassword::FiSH11_SetManualChannelKeyFromPassword;
 pub use fish11_hasmanualchannelkey::FiSH11_HasManualChannelKey;
 pub use fish11_hasratchetchannelkey::FiSH11_HasRatchetChannelKey;
 pub use fish11_removemanualchannelkey::FiSH11_RemoveManualChannelKey;

--- a/scripts/mirc/fish_11.mrc
+++ b/scripts/mirc/fish_11.mrc
@@ -1368,7 +1368,7 @@ alias INI_GetInt {
 ; Menu for channel windows
 menu channel {
   -
-  FiSH Channel Encryption
+  FiSH_11 channel encryption
   .Add a channel key encryption
   ..Manual key : fish11_set_manual_key_dialog $chan
   ..FCEP-1 key : fish11_init_fcep_dialog $chan
@@ -1376,8 +1376,8 @@ menu channel {
   ..Enable topic encryption :{ fish11_SetChannelIniValue $chan encrypt_topic 1 | echo $color(Mode text) -at *** FiSH: topic encryption enabled for $chan }
   ..Disable topic encryption :{ fish11_SetChannelIniValue $chan encrypt_topic 0 | echo $color(Mode text) -at *** FiSH: topic encryption disabled for $chan }
   .-
-  .Show Channel Key Info : fish11_show_channel_key_info $chan
-  .Remove Channel Key : fish11_remove_channel_key $chan
+  .Show channel key info : fish11_show_channel_key_info $chan
+  .Remove channel key : fish11_remove_channel_key $chan
   .-
   .Show keychan :fish11_showkey $chan
   .Show fingerprint :fish11_showfingerprint $chan
@@ -1421,7 +1421,7 @@ menu channel {
 ; Menu for query windows
 menu query {
   -
-  FiSH
+  FiSH_11
   .X25519 keyXchange: fish11_X25519_INIT $1
   .-
   .Show key :fish11_showkey $1
@@ -1463,7 +1463,7 @@ menu query {
 ; Menu for nicklist
 menu nicklist {
   -
-  FiSH
+  FiSH_11
   .X25519 keyXchange: fish11_X25519_INIT $1
   .-
   .Show key :fish11_showkey $1
@@ -1502,7 +1502,7 @@ menu status,channel,nicklist,query {
   .Injection version : fish11_injection_version
   .Help :fish11_help
   .-
-  .Master Key
+  .Master key
   ..Unlock master key :fish11_unlock
   ..Lock master key :fish11_lock
   ..Show master key status :fish11_masterkey_status
@@ -1516,9 +1516,9 @@ menu status,channel,nicklist,query {
     var %topic = $?="Enter encrypted topic for " $+ $active $+ ":"
     if (%topic != $null) etopic %topic
   }
-  .Add Channel Key Encryption :{
-    ; Only allow in channel windows
-    if ($chantype($active) != # && $chantype($active) != &) {
+  .Add channel key encryption :{
+    ; Only allow in channel windows (more robust check)
+    if ($window($active).type != channel) {
       echo $color(Mode text) -at *** FiSH_11: This command can only be used in channel windows
       return
     }
@@ -1550,11 +1550,11 @@ menu status,channel,nicklist,query {
   ...Enable :{ fish11_SetIniValue process_incoming 1 | echo $color(Mode text) -at *** FiSH: incoming message decryption enabled }
   ...Disable :{ fish11_SetIniValue process_incoming 0 | echo $color(Mode text) -at *** FiSH: incoming message decryption disabled }
   ..-
-  ..Crypt-Mark (Incoming)
+  ..Crypt-mark (Incoming)
   ...Prefix :{ fish11_SetIniValue mark_position 2 | echo $color(Mode text) -at *** FiSH: encryption mark set to prefix }
   ...Suffix :{ fish11_SetIniValue mark_position 1 | echo $color(Mode text) -at *** FiSH: encryption mark set to suffix }
   ...Disable :{ fish11_SetIniValue mark_position 0 | echo $color(Mode text) -at *** FiSH: encryption mark disabled }
-  ..Crypt-Mark (Outgoing) $+ $chr(32) $+ %mark_outgoing
+  ..Crypt-mark (Outgoing) $+ $chr(32) $+ %mark_outgoing
   ...Enable :set %mark_outgoing [On]
   ...Disable :set %mark_outgoing [Off]
   ...-
@@ -1588,8 +1588,8 @@ menu status,channel,nicklist,query {
   ..-
   ..Open config file :fish11_ViewIniFile
   ..-
-  ..FiSH 11 - secure IRC encryption :shell -o https://github.com/ggielly/fish_11
-  .Backup and Restore
+  ..FiSH_11 - secure IRC encryption :shell -o https://github.com/ggielly/fish_11
+  .Backup and restore
   ..Create backup now :fish11_ScheduleBackup
   ..Restore from backup :{
     var %file = $sfile($+(",$mircdir,fish_11\backups\"),Restore FiSH keys from:,*.bak)
@@ -1728,8 +1728,8 @@ alias fish_logdecryptfile11 { fish11_logdecryptfile $1- }
 
 ; Direct command for channel encryption settings
 alias fish11_channel_settings {
-  ; Check if we're in a channel window
-  if ($chantype($active) != # && $chantype($active) != &) {
+  ; Check if we're in a channel window (more robust check)
+  if ($window($active).type != channel) {
     echo $color(Mode text) -at *** FiSH_11: This command can only be used in channel windows
     return
   }
@@ -1753,9 +1753,9 @@ alias fcs { fish11_channel_settings }
 
 ; Boîte de dialogue pour la clé manuelle
 alias fish11_set_manual_key_dialog {
-  ; Vérifier si nous sommes dans une fenêtre de canal
-  if ($chantype($active) != # && $chantype($active) != &) {
-    echo $color(Error) -at *** FiSH_11: Manual key can only be set for channels. Please use this in a channel window.
+  ; Vérifier si nous sommes dans une fenêtre de canal (méthode plus robuste)
+  if ($window($active).type != channel) {
+    echo $color(Error) -at *** FiSH_11: Manual key can only be set for channels. Current window: $active (type: $window($active).type)
     return
   }
   
@@ -1769,9 +1769,9 @@ alias fish11_set_manual_key_dialog {
 
 ; Boîte de dialogue pour FCEP-1
 alias fish11_init_fcep_dialog {
-  ; Vérifier si nous sommes dans une fenêtre de canal
-  if ($chantype($active) != # && $chantype($active) != &) {
-    echo $color(Error) -at *** FiSH_11: FCEP-1 key can only be set for channels. Please use this in a channel window.
+  ; Vérifier si nous sommes dans une fenêtre de canal (méthode plus robuste)
+  if ($window($active).type != channel) {
+    echo $color(Error) -at *** FiSH_11: FCEP-1 key can only be set for channels. Current window: $active (type: $window($active).type)
     return
   }
   

--- a/scripts/mirc/fish_11.mrc
+++ b/scripts/mirc/fish_11.mrc
@@ -1369,10 +1369,10 @@ alias INI_GetInt {
 menu channel {
   -
   FiSH Channel Encryption
+  .Add a channel key encryption
+  ..Manual Key : fish11_set_manual_key_dialog $chan
+  ..FCEP-1 Key : fish11_init_fcep_dialog $chan
   .Encrypt TOPIC
-  ..Set Encryption Method
-  ...Manual Key : fish11_set_manual_key_dialog $chan
-  ...FCEP-1 Key : fish11_init_fcep_dialog $chan
   ..Enable Topic Encryption :{ fish11_SetChannelIniValue $chan encrypt_topic 1 | echo $color(Mode text) -at *** FiSH: topic encryption enabled for $chan }
   ..Disable Topic Encryption :{ fish11_SetChannelIniValue $chan encrypt_topic 0 | echo $color(Mode text) -at *** FiSH: topic encryption disabled for $chan }
   .-
@@ -1516,14 +1516,14 @@ menu status,channel,nicklist,query {
     var %topic = $?="Enter encrypted topic for " $+ $active $+ ":"
     if (%topic != $null) etopic %topic
   }
-  .Channel Encryption Settings :{
+  .Add Channel Key Encryption :{
     ; Only allow in channel windows
     if ($chantype($active) != # && $chantype($active) != &) {
       echo $color(Mode text) -at *** FiSH_11: This command can only be used in channel windows
       return
     }
     ; Open a dialog to choose encryption method
-    var %choice = $input(Channel Encryption for $active $+ :, pvq, FiSH_11 Channel Settings)
+    var %choice = $input(Add Channel Key Encryption for $active $+ :, pvq, FiSH_11 Add Channel Key)
     if (%choice == $null) return
     
     if (%choice == 1) {
@@ -1533,14 +1533,6 @@ menu status,channel,nicklist,query {
     elseif (%choice == 2) {
       ; Set FCEP-1 Key
       fish11_init_fcep_dialog $active
-    }
-    elseif (%choice == 3) {
-      ; Show Key Info
-      fish11_show_channel_key_info $active
-    }
-    elseif (%choice == 4) {
-      ; Remove Key
-      fish11_remove_channel_key $active
     }
   }
   .List all keys :fish11_file_list_keys
@@ -1743,7 +1735,7 @@ alias fish11_channel_settings {
   }
   
   ; Open a dialog to choose encryption method
-  var %choice = $input(Channel Encryption for $active $+ :, pvq, FiSH_11 Channel Settings)
+  var %choice = $input(Add Channel Key Encryption for $active $+ :, pvq, FiSH_11 Add Channel Key)
   if (%choice == $null) return
   
   if (%choice == 1) {
@@ -1753,14 +1745,6 @@ alias fish11_channel_settings {
   elseif (%choice == 2) {
     ; Set FCEP-1 Key
     fish11_init_fcep_dialog $active
-  }
-  elseif (%choice == 3) {
-    ; Show Key Info
-    fish11_show_channel_key_info $active
-  }
-  elseif (%choice == 4) {
-    ; Remove Key
-    fish11_remove_channel_key $active
   }
 }
 

--- a/scripts/mirc/fish_11.mrc
+++ b/scripts/mirc/fish_11.mrc
@@ -1734,6 +1734,39 @@ alias fish_logencrypt11 { fish11_logencrypt $1- }
 alias fish_logdecrypt11 { fish11_logdecrypt $1- }
 alias fish_logdecryptfile11 { fish11_logdecryptfile $1- }
 
+; Direct command for channel encryption settings
+alias fish11_channel_settings {
+  ; Check if we're in a channel window
+  if ($chantype($active) != # && $chantype($active) != &) {
+    echo $color(Mode text) -at *** FiSH_11: This command can only be used in channel windows
+    return
+  }
+  
+  ; Open a dialog to choose encryption method
+  var %choice = $input(Channel Encryption for $active $+ :, pvq, FiSH_11 Channel Settings)
+  if (%choice == $null) return
+  
+  if (%choice == 1) {
+    ; Set Manual Key
+    fish11_set_manual_key_dialog $active
+  }
+  elseif (%choice == 2) {
+    ; Set FCEP-1 Key
+    fish11_init_fcep_dialog $active
+  }
+  elseif (%choice == 3) {
+    ; Show Key Info
+    fish11_show_channel_key_info $active
+  }
+  elseif (%choice == 4) {
+    ; Remove Key
+    fish11_remove_channel_key $active
+  }
+}
+
+; Short alias for channel settings
+alias fcs { fish11_channel_settings }
+
 ; Boîte de dialogue pour la clé manuelle
 alias fish11_set_manual_key_dialog {
   var %channel = $1

--- a/scripts/mirc/fish_11.mrc
+++ b/scripts/mirc/fish_11.mrc
@@ -1370,11 +1370,11 @@ menu channel {
   -
   FiSH Channel Encryption
   .Add a channel key encryption
-  ..Manual Key : fish11_set_manual_key_dialog $chan
-  ..FCEP-1 Key : fish11_init_fcep_dialog $chan
-  .Encrypt TOPIC
-  ..Enable Topic Encryption :{ fish11_SetChannelIniValue $chan encrypt_topic 1 | echo $color(Mode text) -at *** FiSH: topic encryption enabled for $chan }
-  ..Disable Topic Encryption :{ fish11_SetChannelIniValue $chan encrypt_topic 0 | echo $color(Mode text) -at *** FiSH: topic encryption disabled for $chan }
+  ..Manual key : fish11_set_manual_key_dialog $chan
+  ..FCEP-1 key : fish11_init_fcep_dialog $chan
+  .Encrypt topic
+  ..Enable topic encryption :{ fish11_SetChannelIniValue $chan encrypt_topic 1 | echo $color(Mode text) -at *** FiSH: topic encryption enabled for $chan }
+  ..Disable topic encryption :{ fish11_SetChannelIniValue $chan encrypt_topic 0 | echo $color(Mode text) -at *** FiSH: topic encryption disabled for $chan }
   .-
   .Show Channel Key Info : fish11_show_channel_key_info $chan
   .Remove Channel Key : fish11_remove_channel_key $chan
@@ -1753,7 +1753,13 @@ alias fcs { fish11_channel_settings }
 
 ; Boîte de dialogue pour la clé manuelle
 alias fish11_set_manual_key_dialog {
-  var %channel = $1
+  ; Vérifier si nous sommes dans une fenêtre de canal
+  if ($chantype($active) != # && $chantype($active) != &) {
+    echo $color(Error) -at *** FiSH_11: Manual key can only be set for channels. Please use this in a channel window.
+    return
+  }
+  
+  var %channel = $active
   var %key = $input(Enter 44-character base64 manual key for %channel $+ :, pvq, FiSH_11 Manual Channel Key)
 
   if (%key != $null) {
@@ -1763,7 +1769,13 @@ alias fish11_set_manual_key_dialog {
 
 ; Boîte de dialogue pour FCEP-1
 alias fish11_init_fcep_dialog {
-  var %channel = $1
+  ; Vérifier si nous sommes dans une fenêtre de canal
+  if ($chantype($active) != # && $chantype($active) != &) {
+    echo $color(Error) -at *** FiSH_11: FCEP-1 key can only be set for channels. Please use this in a channel window.
+    return
+  }
+  
+  var %channel = $active
   var %members = $input(Enter members to invite (space-separated) for %channel $+ :, pvq, FiSH_11 FCEP-1 Channel Setup)
 
   if (%members != $null) {

--- a/scripts/mirc/fish_11.mrc
+++ b/scripts/mirc/fish_11.mrc
@@ -490,14 +490,17 @@ alias fish11_setkey_manual {
 
   ; Vérifier que la clé est en base64 et fait 44 caractères (32 bytes encodés)
   var %key = $2-
-  if ($len(%key) != 44 || $regex(%key, /[^A-Za-z0-9+\/=]/)) {
-    echo 4 -a Error: Key must be a 44-character base64-encoded 32-byte cryptographic key
-    return
+  
+  if ($len(%key) == 44 && $regex(%key, /^[A-Za-z0-9+\/=]+$/)) {
+    ; Clé base64 valide - utiliser la fonction standard
+    var %input = $+(%channel, $chr(32), %key)
+    var %msg = $dll(%Fish11DllFile, FiSH11_SetManualChannelKey, %input)
   }
-
-  ; Appeler la bonne fonction DLL avec le bon format
-  var %input = $+(%channel, $chr(32), %key)
-  var %msg = $dll(%Fish11DllFile, FiSH11_SetManualChannelKey, %input)
+  else {
+    ; Clé non-base64 ou de longueur différente - utiliser la fonction d'extension
+    var %input = $+(%channel, $chr(32), %key)
+    var %msg = $dll(%Fish11DllFile, FiSH11_SetManualChannelKeyFromPassword, %input)
+  }
 
   if (%msg && $left(%msg, 6) != Error:) {
     echo -a *** FiSH_11: manual channel key set for %channel

--- a/scripts/mirc/fish_11.mrc
+++ b/scripts/mirc/fish_11.mrc
@@ -1516,6 +1516,33 @@ menu status,channel,nicklist,query {
     var %topic = $?="Enter encrypted topic for " $+ $active $+ ":"
     if (%topic != $null) etopic %topic
   }
+  .Channel Encryption Settings :{
+    ; Only allow in channel windows
+    if ($chantype($active) != # && $chantype($active) != &) {
+      echo $color(Mode text) -at *** FiSH_11: This command can only be used in channel windows
+      return
+    }
+    ; Open a dialog to choose encryption method
+    var %choice = $input(Channel Encryption for $active $+ :, pvq, FiSH_11 Channel Settings)
+    if (%choice == $null) return
+    
+    if (%choice == 1) {
+      ; Set Manual Key
+      fish11_set_manual_key_dialog $active
+    }
+    elseif (%choice == 2) {
+      ; Set FCEP-1 Key
+      fish11_init_fcep_dialog $active
+    }
+    elseif (%choice == 3) {
+      ; Show Key Info
+      fish11_show_channel_key_info $active
+    }
+    elseif (%choice == 4) {
+      ; Remove Key
+      fish11_remove_channel_key $active
+    }
+  }
   .List all keys :fish11_file_list_keys
   .Test encryption :fish11_test_crypt
   .-

--- a/scripts/mirc/fish_11.mrc
+++ b/scripts/mirc/fish_11.mrc
@@ -504,8 +504,8 @@ alias fish11_setkey_manual {
 
   if (%msg && $left(%msg, 6) != Error:) {
     echo -a *** FiSH_11: manual channel key set for %channel
-    ; Activer automatiquement le chiffrement des topics pour ce canal
-    fish11_SetChannelIniValue %channel encrypt_topic 1
+    ; Note: Topic encryption must be enabled manually via the channel menu
+    ; fish11_SetChannelIniValue %channel encrypt_topic 1
   }
   else {
     var %error_msg = $iif(%msg, %msg, "Unknown error - could not set manual key for %channel")


### PR DESCRIPTION
Add managing channel keys in the FiSH11 DLL, including checking for the existence of manual and ratchet channel keys + removing them, and setting manual keys from passwords. 


### Channel key management helpers (core logic)
* Added helper functions to `config/mod.rs` for checking (`has_manual_channel_key`, `has_ratchet_channel_key`) and removing (`remove_manual_channel_key`, `remove_ratchet_channel_key`) both manual and ratchet channel keys for a given channel. 

### Dll interface functions (API surface)
* Added four missing DLL interface modules for mIRC integration :
  - [`fish11_hasmanualchannelkey.rs`](diffhunk://#diff-acd15b712cc27a29ba68f0a3d2d6e2b4aaba0883650389e647029f61f3829059R1-R105) : checks if a manual channel key exists for a channel, with input validation and tests.
  - [`fish11_hasratchetchannelkey.rs`](diffhunk://#diff-f5a1dc457f021af70917fbf482a32ccff13c8cc00888ec9e0488b1e39b4e4eb7R1-R84) : checks if a ratchet channel key exists for a channel, with input validation and tests.
  - [`fish11_removemanualchannelkey.rs`](diffhunk://#diff-7e51a50104b07780433d144999d3bfc9f63d581359fe5ff3604c1f3af05153b4R1-R88): removes a manual channel key for a channel, idempotent and validated, with tests.
  - [`fish11_removeratchetchannelkey.rs`](diffhunk://#diff-227a2d932c0586cb42a8fca04ebcb80f64263387976d534564eaf1c2eaa33dccR1-R88): removes a ratchet channel key for a channel, idempotent and validated, with tests.

### Setting manual channel key from password (feature expansion)
* Introduced `fish11_setmanualchannelkeyfrompassword.rs`, which allows setting a manual channel key using a password or short key, securely expanding it to 32 bytes using HKDF-SHA256.
### Tests
* Refactored `fish11_setmanualchannelkey.rs` to expose its test helper function publicly . [[1]](diffhunk://#diff-eb5c9fb2faccb5d7a991da359e321469f84321170bdb7f7e2ba8664d7827f7ffL68-R104) [[2]](diffhunk://#diff-eb5c9fb2faccb5d7a991da359e321469f84321170bdb7f7e2ba8664d7827f7ffL5-R7)
