### PR TITLE
Fix/inject buffer safety

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -339,9 +339,9 @@ dependencies = [
 
 [[package]]
 name = "crypto-common"
-version = "0.2.1"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77727bb15fa921304124b128af125e7e3b968275d1b108b379190264f4423710"
+checksum = "ce6e4c961d6cd6c9a86db418387425e8bdeaf05b3c8bc1411e6dca4c252f1453"
 dependencies = [
  "hybrid-array",
 ]
@@ -480,7 +480,7 @@ checksum = "4850db49bf08e663084f7fb5c87d202ef91a3907271aff24a94eb97ff039153c"
 dependencies = [
  "block-buffer 0.12.0",
  "const-oid",
- "crypto-common 0.2.1",
+ "crypto-common 0.2.2",
 ]
 
 [[package]]
@@ -1107,9 +1107,9 @@ checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 
 [[package]]
 name = "rand"
-version = "0.8.5"
+version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
+checksum = "5ca0ecfa931c29007047d1bc58e623ab12e5590e8c7cc53200d5202b69266d8a"
 dependencies = [
  "libc",
  "rand_chacha",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,3 +9,21 @@ resolver = "2"
 [workspace.metadata]
 # Configuration par défaut pour Windows
 default-target = "i686-pc-windows-msvc"
+
+[profile.dev]
+opt-level = 0      # No optimization for faster compilation
+debug = 2          # Full debug information (maximum)
+strip = false      # Keep all symbols
+panic = "unwind"   # Full stack traces for debugging
+incremental = true # Faster recompilation
+lto = false        # Faster compilation
+
+[profile.release]
+opt-level = "z"   # Optimize for size
+lto = true        # Link Time Optimization
+codegen-units = 1 # Maximum optimization
+panic = "abort"   # Remove unwinding code
+strip = true      # Remove symbols
+
+[profile.release.package."*"]
+codegen-units = 1

--- a/fish_11_cli/Cargo.toml
+++ b/fish_11_cli/Cargo.toml
@@ -17,20 +17,3 @@ winapi = { version = "0.3", features = ["winuser", "windef", "libloaderapi"] }
 [build-dependencies]
 vergen = { version = "9.0.6", features = ["build", "cargo", "rustc", "si"] }
 
-[profile.dev]
-opt-level = 0      # No optimization for faster compilation
-debug = 2          # Full debug information (maximum)
-strip = false      # Keep all symbols
-panic = "unwind"   # Full stack traces for debugging
-incremental = true # Faster recompilation
-lto = false        # Faster compilation
-
-[profile.release]
-opt-level = "z"   # Optimize for size
-lto = true        # Link Time Optimization
-codegen-units = 1 # Maximum optimization
-panic = "abort"   # Remove unwinding code
-strip = true      # Remove symbols
-
-[profile.release.package."*"]
-codegen-units = 1

--- a/fish_11_core/Cargo.toml
+++ b/fish_11_core/Cargo.toml
@@ -16,7 +16,7 @@ regex = "1.11.1"
 log = { version = "0.4", features = ["std"] }
 chrono = { version = "0.4", features = ["serde"] }
 lazy_static = "1.4"
-rand = "0.8.5"
+rand = "0.8.6"
 scopeguard = "1.2.0"
 argon2 = "0.5"
 chacha20poly1305 = "0.10"

--- a/fish_11_core/Cargo.toml
+++ b/fish_11_core/Cargo.toml
@@ -33,20 +33,3 @@ tempfile = "3.24.0"
 [build-dependencies]
 vergen = { version = "9.0.6", features = ["build", "cargo", "rustc", "si"] }
 
-[profile.dev]
-opt-level = 0      # No optimization for faster compilation
-debug = 2          # Full debug information (maximum)
-strip = false      # Keep all symbols
-panic = "unwind"   # Full stack traces for debugging
-incremental = true # Faster recompilation
-lto = false        # Faster compilation
-
-[profile.release]
-opt-level = "z"   # Optimize for size
-lto = true        # Link Time Optimization
-codegen-units = 1 # Maximum optimization
-panic = "abort"   # Remove unwinding code
-strip = true      # Remove symbols
-
-[profile.release.package."*"]
-codegen-units = 1

--- a/fish_11_core/src/buffer_utils.rs
+++ b/fish_11_core/src/buffer_utils.rs
@@ -3,9 +3,10 @@
 //! This module provides buffer management functions that are independent of
 //! platform-specific interfaces. The actual buffer I/O will be handled by
 //! wrapper crates (fish_11_dll, fish_11_lib).
-use crate::globals::MIRC_DLL_RESULT_PAYLOAD_CAP;
 use std::ffi::{CStr, CString, c_char};
 use std::ptr;
+
+use crate::globals::MIRC_DLL_RESULT_PAYLOAD_CAP;
 
 /// Result type for buffer operations
 pub type BufferResult<T> = Result<T, BufferError>;

--- a/fish_11_core/src/config/encrypted_config.rs
+++ b/fish_11_core/src/config/encrypted_config.rs
@@ -3,12 +3,13 @@
 //! Provides functions for securely storing and loading configuration files
 //! using the master key encryption system.
 
-use crate::master_key::{
-    derivation::derive_config_kek,
-    encryption::{EncryptedBlob, decrypt_data, encrypt_data},
-};
-use base64::{Engine as _, engine::general_purpose};
 use std::path::PathBuf;
+
+use base64::Engine as _;
+use base64::engine::general_purpose;
+
+use crate::master_key::derivation::derive_config_kek;
+use crate::master_key::encryption::{EncryptedBlob, decrypt_data, encrypt_data};
 
 /// Header for encrypted configuration files
 const ENCRYPTED_CONFIG_HEADER: &str = "# FiSH_11_ENCRYPTED_CONFIG_V1";

--- a/fish_11_core/src/logging/config.rs
+++ b/fish_11_core/src/logging/config.rs
@@ -1,5 +1,6 @@
-use log::LevelFilter;
 use std::path::PathBuf;
+
+use log::LevelFilter;
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub enum LoggingProfile {

--- a/fish_11_core/src/logging/context.rs
+++ b/fish_11_core/src/logging/context.rs
@@ -1,7 +1,8 @@
-use chrono::{DateTime, Local};
 use std::cell::RefCell;
 use std::fmt;
 use std::sync::atomic::{AtomicU64, Ordering};
+
+use chrono::{DateTime, Local};
 
 thread_local!(static CONTEXT: RefCell<Option<LogContext>> = RefCell::new(None));
 

--- a/fish_11_core/src/logging/formatter.rs
+++ b/fish_11_core/src/logging/formatter.rs
@@ -1,7 +1,8 @@
+use log::Record;
+
 use crate::logging::config::LogConfig;
 use crate::logging::context::LogContext;
 use crate::logging::security;
-use log::Record;
 
 pub fn format_record(record: &Record, context: &LogContext, config: &LogConfig) -> String {
     let mut message = format!("{}", record.args());
@@ -29,11 +30,8 @@ pub fn format_record(record: &Record, context: &LogContext, config: &LogConfig) 
         metadata.push(format!("{}:{}", file, line));
     }
 
-    let metadata = metadata
-        .into_iter()
-        .map(|segment| format!("[{}]", segment))
-        .collect::<Vec<_>>()
-        .join(" ");
+    let metadata =
+        metadata.into_iter().map(|segment| format!("[{}]", segment)).collect::<Vec<_>>().join(" ");
 
     format!("[{}] {} {}\n", timestamp, metadata, message)
 }
@@ -44,8 +42,9 @@ fn add_context(message: &str, context: &LogContext) -> String {
 
 #[cfg(test)]
 mod tests {
-    use super::*;
     use log::{Level, Record};
+
+    use super::*;
 
     #[test]
     fn inject_profile_formats_with_source_location() {

--- a/fish_11_core/src/logging/writers/console_writer.rs
+++ b/fish_11_core/src/logging/writers/console_writer.rs
@@ -1,9 +1,11 @@
+use std::io::{self, Write};
+
+use log::{LevelFilter, Record};
+
 use crate::logging::config::LogConfig;
 use crate::logging::context::LogContext;
 use crate::logging::errors::LogError;
 use crate::logging::formatter;
-use log::{LevelFilter, Record};
-use std::io::{self, Write};
 
 pub struct ConsoleWriter {
     level: LevelFilter,

--- a/fish_11_core/src/logging/writers/file_writer.rs
+++ b/fish_11_core/src/logging/writers/file_writer.rs
@@ -1,15 +1,17 @@
-use crate::logging::config::LogConfig;
-use crate::logging::context::LogContext;
-use crate::logging::errors::LogError;
-use crate::logging::formatter;
-use log::Record;
-use rand::Rng;
-use scopeguard;
 use std::fs::{File, OpenOptions};
 use std::io::{BufWriter, Write};
 use std::path::Path;
 use std::sync::{Arc, Mutex};
 use std::time::Duration;
+
+use log::Record;
+use rand::Rng;
+use scopeguard;
+
+use crate::logging::config::LogConfig;
+use crate::logging::context::LogContext;
+use crate::logging::errors::LogError;
+use crate::logging::formatter;
 
 pub struct FileWriter {
     file: Arc<Mutex<BufWriter<File>>>,

--- a/fish_11_core/src/master_key/core/config_key.rs
+++ b/fish_11_core/src/master_key/core/config_key.rs
@@ -1,10 +1,12 @@
 // Configuration Key - Specialized key for encrypting/decrypting configuration
 
-use super::master_key::MasterKey;
+use std::sync::{Arc, Mutex};
+
 use base64::Engine;
 use chacha20poly1305::aead::{Aead, KeyInit};
 use chacha20poly1305::{ChaCha20Poly1305, Key};
-use std::sync::{Arc, Mutex};
+
+use super::master_key::MasterKey;
 
 /// Configuration Key - derived from MasterKey for config encryption
 #[derive(Debug, Clone)]

--- a/fish_11_core/src/master_key/core/master_key.rs
+++ b/fish_11_core/src/master_key/core/master_key.rs
@@ -1,9 +1,10 @@
 // Master Key Core - Primary key that protects all other keys
 
+use std::sync::{Arc, Mutex};
+
 use chacha20poly1305::aead::{Aead, KeyInit};
 use chacha20poly1305::{ChaCha20Poly1305, Key};
 use sha2::{Digest, Sha256};
-use std::sync::{Arc, Mutex};
 
 /// Primary Master Key - protects all other keys in the system
 #[derive(Debug, Clone)]

--- a/fish_11_core/src/master_key/core/mod.rs
+++ b/fish_11_core/src/master_key/core/mod.rs
@@ -3,8 +3,9 @@
 
 pub mod config_key;
 pub mod master_key;
-use once_cell::sync::Lazy;
 use std::sync::Mutex;
+
+use once_cell::sync::Lazy;
 
 /// Global key system state
 struct KeySystemState {
@@ -57,8 +58,5 @@ pub fn rotate_all_keys() {
 }
 
 // Public exports for the core key system
-pub use config_key::ConfigKey;
-pub use master_key::MasterKey;
-
-pub use config_key::ConfigKeyGuard;
-pub use master_key::MasterKeyGuard;
+pub use config_key::{ConfigKey, ConfigKeyGuard};
+pub use master_key::{MasterKey, MasterKeyGuard};

--- a/fish_11_core/src/master_key/derivation.rs
+++ b/fish_11_core/src/master_key/derivation.rs
@@ -3,7 +3,8 @@
 //! Handles the derivation of the master key from a password using Argon2id,
 //! and derivation of subkeys using HKDF with proper context separation.
 
-use argon2::{Algorithm, Argon2, Params, PasswordHasher, Version, password_hash::SaltString};
+use argon2::password_hash::SaltString;
+use argon2::{Algorithm, Argon2, Params, PasswordHasher, Version};
 use hkdf::Hkdf;
 use sha2::Sha256;
 

--- a/fish_11_core/src/master_key/encryption.rs
+++ b/fish_11_core/src/master_key/encryption.rs
@@ -26,13 +26,12 @@
 //! If your use case requires deterministic, sequential nonces (e.g., for audit trails or
 //! message ordering), use the `NonceManager` functions below.
 
-use chacha20poly1305::{
-    ChaCha20Poly1305, Key, Nonce,
-    aead::{Aead, KeyInit},
-};
-use once_cell::sync::Lazy;
 use std::collections::{HashMap, HashSet};
 use std::sync::Mutex;
+
+use chacha20poly1305::aead::{Aead, KeyInit};
+use chacha20poly1305::{ChaCha20Poly1305, Key, Nonce};
+use once_cell::sync::Lazy;
 
 /// Nonce manager for counter-based nonce generation
 static NONCE_MANAGER: Lazy<Mutex<NonceManager>> = Lazy::new(|| Mutex::new(NonceManager::new()));

--- a/fish_11_core/src/master_key/keystore.rs
+++ b/fish_11_core/src/master_key/keystore.rs
@@ -2,17 +2,17 @@
 //!
 //! Handles persistent storage of sensitive data like salts, nonce counters, etc.
 
-use base64::{Engine as _, engine::general_purpose};
-use chacha20poly1305::{
-    ChaCha20Poly1305, Key, Nonce,
-    aead::{Aead, KeyInit},
-};
+use std::collections::HashMap;
+use std::path::PathBuf;
+
+use base64::Engine as _;
+use base64::engine::general_purpose;
+use chacha20poly1305::aead::{Aead, KeyInit};
+use chacha20poly1305::{ChaCha20Poly1305, Key, Nonce};
 use configparser::ini::Ini;
 use rand::RngCore;
 use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
-use std::collections::HashMap;
-use std::path::PathBuf;
 
 /// Metadata associated with keys
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/fish_11_core/src/master_key/keystore_encryption.rs
+++ b/fish_11_core/src/master_key/keystore_encryption.rs
@@ -1,13 +1,14 @@
 //! Keystore encryption module
 //! Provides functions to encrypt and decrypt keystore data
 
-use crate::master_key::keystore::Keystore;
-use base64::{Engine as _, engine::general_purpose};
-use chacha20poly1305::{
-    ChaCha20Poly1305, Key, Nonce,
-    aead::{Aead, KeyInit},
-};
 use std::path::PathBuf;
+
+use base64::Engine as _;
+use base64::engine::general_purpose;
+use chacha20poly1305::aead::{Aead, KeyInit};
+use chacha20poly1305::{ChaCha20Poly1305, Key, Nonce};
+
+use crate::master_key::keystore::Keystore;
 
 /// Header for encrypted keystore files
 const ENCRYPTED_KEYSTORE_HEADER: &str = "# FiSH_11_ENCRYPTED_KEYSTORE_V1\n";
@@ -460,9 +461,11 @@ pub fn load_encrypted_keystore_from_path_with_key(
 
 #[cfg(test)]
 mod tests {
-    use super::*;
     use std::fs;
+
     use tempfile::NamedTempFile;
+
+    use super::*;
 
     #[test]
     fn test_encrypt_decrypt_roundtrip() {

--- a/fish_11_core/src/master_key/mod.rs
+++ b/fish_11_core/src/master_key/mod.rs
@@ -22,8 +22,8 @@ pub mod password_validation;
 pub mod rotation;
 // New core system exports
 pub use core::{
-    ConfigKey, ConfigKeyGuard, MasterKey, MasterKeyGuard, get_config_key,
-    initialize_key_system, is_key_system_unlocked, lock_key_system, rotate_all_keys,
+    ConfigKey, ConfigKeyGuard, MasterKey, MasterKeyGuard, get_config_key, initialize_key_system,
+    is_key_system_unlocked, lock_key_system, rotate_all_keys,
 };
 
 // Legacy system exports (to be deprecated)

--- a/fish_11_core/src/master_key/password_change.rs
+++ b/fish_11_core/src/master_key/password_change.rs
@@ -53,9 +53,10 @@ pub fn change_master_password(
     new_password: &str,
     password_verifier: Option<&str>,
 ) -> ChangePasswordResult<String> {
+    use sha2::{Digest, Sha256};
+
     use crate::master_key::derivation::derive_master_key_with_salt;
     use crate::master_key::password_validation::PasswordValidator;
-    use sha2::{Digest, Sha256};
 
     // Validate the new password strength
     PasswordValidator::validate_password_strength(new_password)

--- a/fish_11_dll/Cargo.toml
+++ b/fish_11_dll/Cargo.toml
@@ -74,20 +74,3 @@ post-build = [
     "-outputresource:target/debug/fish_11.dll;2",
 ]
 
-[profile.dev]
-opt-level = 0      # No optimization for faster compilation
-debug = 2          # Full debug information (maximum)
-strip = false      # Keep all symbols
-panic = "unwind"   # Full stack traces for debugging
-incremental = true # Faster recompilation
-lto = false        # Faster compilation
-
-[profile.release]
-opt-level = "z"   # Optimize for size
-lto = true        # Link Time Optimization
-codegen-units = 1 # Maximum optimization
-panic = "abort"   # Remove unwinding code
-strip = true      # Remove symbols
-
-[profile.release.package."*"]
-codegen-units = 1

--- a/fish_11_dll/src/engine_registration.rs
+++ b/fish_11_dll/src/engine_registration.rs
@@ -18,6 +18,9 @@ use crate::legacy::fish10_message_detection;
 type GetNetworkNameFn = unsafe extern "C" fn(u32) -> *mut c_char;
 static GET_NETWORK_NAME_FN: OnceCell<GetNetworkNameFn> = OnceCell::new();
 
+type FreeStringFn = unsafe extern "C" fn(*mut c_char);
+static GET_FREE_STRING_FN: OnceCell<FreeStringFn> = OnceCell::new();
+
 // C-style struct for engine registration
 #[repr(C)]
 pub struct FishInjectEngine {
@@ -960,6 +963,21 @@ pub fn register_engine() {
             }
         }
 
+        let free_string_fn_name = CString::new("FreeString").unwrap();
+        let free_string_fn =
+            GetProcAddress(h_module, PCSTR(free_string_fn_name.as_ptr() as *const u8));
+
+        if free_string_fn.is_none() {
+            #[cfg(debug_assertions)]
+            log_warn!("FreeString function not found in fish_11_inject.dll.");
+        } else {
+            let free_string_fn_ptr: FreeStringFn = std::mem::transmute(free_string_fn.unwrap());
+            if let Err(_) = GET_FREE_STRING_FN.set(free_string_fn_ptr) {
+                #[cfg(debug_assertions)]
+                log_error!("FreeString function already set, this should not happen.");
+            }
+        }
+
         let register_fn_name = CString::new("RegisterEngine").unwrap();
         let register_fn = GetProcAddress(h_module, PCSTR(register_fn_name.as_ptr() as *const u8));
 
@@ -988,11 +1006,17 @@ pub fn get_network_name_from_inject(socket_id: u32) -> Option<String> {
             let c_char_ptr = get_network_name_fn(socket_id);
 
             if !c_char_ptr.is_null() {
-                let c_string = CString::from_raw(c_char_ptr);
+                // Use CStr::from_ptr to borrow the string, then copy it to a Rust String,
+                // and free via the inject DLL's FreeString to respect the API contract.
+                // Using CString::from_raw would take ownership and free with the wrong allocator.
+                let c_str = std::ffi::CStr::from_ptr(c_char_ptr);
+                let rust_string = c_str.to_string_lossy().into_owned();
 
-                if let Ok(rust_string) = c_string.into_string() {
-                    return Some(rust_string);
+                if let Some(free_string_fn) = GET_FREE_STRING_FN.get() {
+                    free_string_fn(c_char_ptr);
                 }
+
+                return Some(rust_string);
             }
         }
     }

--- a/fish_11_dll/src/logging.rs
+++ b/fish_11_dll/src/logging.rs
@@ -46,7 +46,9 @@ pub fn init_logger(level: LevelFilter) -> Result<(), LogError> {
     fish_11_core::logging::init_logging(config)?;
 
     if is_logger_initialized() {
-        log_info!("*********** *********** FiSH_11 : core dll logger initialized *************** ***********");
+        log_info!(
+            "*********** *********** FiSH_11 : core dll logger initialized *************** ***********"
+        );
         log_info!("Logger initialized - writing to: {}", log_path.display());
 
         if let Ok(cwd) = std::env::current_dir() {
@@ -54,11 +56,7 @@ pub fn init_logger(level: LevelFilter) -> Result<(), LogError> {
         }
 
         log_info!("FiSH_11 DLL version: {}", BUILD_VERSION);
-        log_info!(
-            "Build date: {}, Build time: {}",
-            BUILD_DATE.as_str(),
-            BUILD_TIME.as_str()
-        );
+        log_info!("Build date: {}, Build time: {}", BUILD_DATE.as_str(), BUILD_TIME.as_str());
     }
 
     Ok(())

--- a/fish_11_inject/Cargo.toml
+++ b/fish_11_inject/Cargo.toml
@@ -46,20 +46,3 @@ path = "../fish_11_core"
 # NO [dependencies] !
 # Intentionally empty to prevent building on non-Windows platforms !
 
-[profile.dev]
-opt-level = 0      # No optimization for faster compilation
-debug = 2          # Full debug information (maximum)
-strip = false      # Keep all symbols
-panic = "unwind"   # Full stack traces for debugging
-incremental = true # Faster recompilation
-lto = false        # Faster compilation
-
-[profile.release]
-opt-level = "z"   # Optimize for size
-lto = true        # Link Time Optimization
-codegen-units = 1 # Maximum optimization
-panic = "abort"   # Remove unwinding code
-strip = true      # Remove symbols
-
-[profile.release.package."*"]
-codegen-units = 1

--- a/fish_11_inject/src/buffer_pool.rs
+++ b/fish_11_inject/src/buffer_pool.rs
@@ -24,11 +24,11 @@ pub struct BufferPool {
 
 /// Statistics about buffer pool usage
 #[derive(Debug, Clone, Default)]
-struct BufferPoolStats {
-    allocations: usize,
-    reuses: usize,
-    current_pool_size: usize,
-    max_pool_size: usize,
+pub struct BufferPoolStats {
+    pub allocations: usize,
+    pub reuses: usize,
+    pub current_pool_size: usize,
+    pub max_pool_size: usize,
 }
 
 impl BufferPool {
@@ -196,8 +196,13 @@ impl SmartBuffer {
 
 impl Drop for SmartBuffer {
     fn drop(&mut self) {
-        // Automatically return the buffer to the pool when dropped
-        self.pool.release(self.buffer.clone());
+        // Take ownership of the buffer without cloning, then release it to the pool.
+        // Using clone() here would create a duplicate : the original would be dropped
+        // normally while the clone is returned to the pool, wasting memory.
+        let buffer = std::mem::take(&mut self.buffer);
+        if !buffer.is_empty() || buffer.capacity() > 0 {
+            self.pool.release(buffer);
+        }
     }
 }
 

--- a/fish_11_inject/src/buffer_pool.rs
+++ b/fish_11_inject/src/buffer_pool.rs
@@ -3,11 +3,12 @@
 //! This module provides a thread-safe buffer pool to reduce memory allocations
 //! and improve performance for socket data processing.
 
+use std::collections::VecDeque;
+use std::sync::Arc;
+
 use bytes::{Bytes, BytesMut};
 use log::{debug, trace};
 use parking_lot::Mutex;
-use std::collections::VecDeque;
-use std::sync::Arc;
 
 /// Maximum buffer size to keep in the pool (in bytes)
 const MAX_POOL_BUFFER_SIZE: usize = 16 * 1024; // 16KB

--- a/fish_11_inject/src/dll_interface.rs
+++ b/fish_11_inject/src/dll_interface.rs
@@ -51,6 +51,7 @@ pub struct LOADINFO {
     pub m_unicode: i32, // mUnicode (BOOL)
     pub m_beta: u32,    // mBeta (DWORD)
     pub m_bytes: u32,   // mBytes (DWORD)
+    pub m_extra: u32,   // mExtra (DWORD) - reserved for future use
 }
 
 #[no_mangle]
@@ -130,11 +131,16 @@ pub extern "stdcall" fn LoadDll(loadinfo: *mut LOADINFO) -> c_int {
             }
         }
         Err(e) => {
-            error!("LoadDll() : failed to lock ENGINES to initialize: {}", e);
+            error!("LoadDll() : failed to lock ENGINES: {}", e);
+            // Poison recovery: the mutex was poisoned by a panic in another thread.
+            // We attempt to recover by using the inner value, but log a warning
+            // as this may indicate corrupted state.
             let mut engines = e.into_inner();
             if engines.is_none() {
                 *engines = Some(std::sync::Arc::new(InjectEngines::new()));
-                warn!("LoadDll() : InjectEngines initialized after lock recovery.");
+                warn!("LoadDll() : InjectEngines initialized after poison recovery. State may be unreliable.");
+            } else {
+                warn!("LoadDll() : reusing existing InjectEngines after poison recovery.");
             }
         }
     }
@@ -461,6 +467,7 @@ mod tests {
             m_keep: 0,
             m_bytes: 4096,
             m_beta: 0,
+            m_extra: 0,
         };
 
         // Test that we can create a LOADINFO struct (compile-time check)

--- a/fish_11_inject/src/dll_interface.rs
+++ b/fish_11_inject/src/dll_interface.rs
@@ -1,17 +1,19 @@
+use std::ffi::{CString, c_char, c_int};
+use std::sync::atomic::Ordering;
+
+use fish_11_core::globals::{
+    BUILD_DATE, BUILD_NUMBER, BUILD_TIME, BUILD_VERSION, MIRC_RETURN_DATA_COMMAND,
+};
+use log::{debug, error, info, warn};
+use windows::Win32::Foundation::{HMODULE, HWND};
+use windows::Win32::UI::WindowsAndMessaging::{MB_ICONEXCLAMATION, MB_OK, MessageBoxW};
+
+use crate::engines::InjectEngines;
 use crate::helpers_inject::{cleanup_hooks, init_logger, install_hooks};
 use crate::{
     ACTIVE_SOCKETS, DISCARDED_SOCKETS, DLL_HANDLE, ENGINES, LOADED, MAX_MIRC_RETURN_BYTES,
     MIRC_HALT, MIRC_IDENTIFIER, VERSION_SHOWN,
 };
-use crate::engines::InjectEngines;
-use fish_11_core::globals::{
-    BUILD_DATE, BUILD_NUMBER, BUILD_TIME, BUILD_VERSION, MIRC_RETURN_DATA_COMMAND,
-};
-use log::{debug, error, info, warn};
-use std::ffi::{CString, c_char, c_int};
-use std::sync::atomic::Ordering;
-use windows::Win32::Foundation::{HMODULE, HWND};
-use windows::Win32::UI::WindowsAndMessaging::{MB_ICONEXCLAMATION, MB_OK, MessageBoxW};
 
 fn write_mirc_output_buffer(
     context: &str,
@@ -138,7 +140,9 @@ pub extern "stdcall" fn LoadDll(loadinfo: *mut LOADINFO) -> c_int {
             let mut engines = e.into_inner();
             if engines.is_none() {
                 *engines = Some(std::sync::Arc::new(InjectEngines::new()));
-                warn!("LoadDll() : InjectEngines initialized after poison recovery. State may be unreliable.");
+                warn!(
+                    "LoadDll() : InjectEngines initialized after poison recovery. State may be unreliable."
+                );
             } else {
                 warn!("LoadDll() : reusing existing InjectEngines after poison recovery.");
             }

--- a/fish_11_inject/src/engines.rs
+++ b/fish_11_inject/src/engines.rs
@@ -1,10 +1,11 @@
 //! This module handles the registration and management of external engines for the FiSH IRC client.
 
+use std::collections::HashMap;
+use std::ffi::{CStr, CString};
+
 use fish_11_core::globals::FISH_INJECT_ENGINE_VERSION;
 use log::{error, info, trace, warn};
 use parking_lot::{Mutex, RwLock};
-use std::collections::HashMap;
-use std::ffi::{CStr, CString};
 
 // C structure definition provided by engines
 #[repr(C)]

--- a/fish_11_inject/src/engines.rs
+++ b/fish_11_inject/src/engines.rs
@@ -53,7 +53,13 @@ pub struct SafeEngine {
     get_network_name_ptr: unsafe extern "C" fn(u32) -> *mut i8,
 }
 
-// Allow sending across threads if InjectEngines is shared via Arc/Mutex/RwLock
+// SAFETY: SafeEngine stores raw function pointers from external DLLs (engines).
+// These pointers are valid as long as the engine DLL is loaded, which is guaranteed
+// by the engine lifecycle management in InjectEngines. The engine DLLs are loaded
+// via LoadLibraryA and unloaded via FreeLibrary only when all references are dropped.
+// All callback invocations go through SafeEngine wrappers that validate pointers
+// before calling. The engine registration API requires engines to provide valid
+// function pointers at registration time, and version compatibility is verified.
 unsafe impl Send for SafeEngine {}
 unsafe impl Sync for SafeEngine {}
 
@@ -353,6 +359,33 @@ impl InjectEngines {
             }
         }
         drop(post); // Release read lock
+
+        modified
+    }
+
+    /// Process an incoming line through all registered engines
+    pub fn on_incoming_irc_line(&self, socket: u32, line: &mut String) -> bool {
+        let mut modified = false;
+
+        // Run pre-processors
+        let pre = self.pre_engines.read();
+
+        for engine in pre.iter() {
+            if engine.on_incoming_irc_line(socket, line) {
+                modified = true;
+            }
+        }
+        drop(pre);
+
+        // Run post-processors
+        let post = self.post_engines.read();
+
+        for engine in post.iter() {
+            if engine.on_incoming_irc_line(socket, line) {
+                modified = true;
+            }
+        }
+        drop(post);
 
         modified
     }

--- a/fish_11_inject/src/helpers_inject.rs
+++ b/fish_11_inject/src/helpers_inject.rs
@@ -1,3 +1,13 @@
+use std::io;
+use std::sync::PoisonError;
+
+use fish_11_core::logging;
+use log::{error, info, warn};
+use retour::GenericDetour;
+use windows::Win32::Foundation::FARPROC;
+use windows::Win32::System::LibraryLoader::{GetModuleHandleA, GetProcAddress};
+use windows::core::PCSTR;
+
 use crate::hook_socket::{
     CLOSESOCKET_HOOK, CONNECT_HOOK, ClosesocketFn, ConnectFn, RECV_HOOK, RecvFn, SEND_HOOK, SendFn,
     hooked_closesocket, hooked_connect, hooked_recv, hooked_send, uninstall_socket_hooks,
@@ -7,14 +17,6 @@ use crate::hook_ssl::{
     uninstall_ssl_hooks,
 };
 use crate::pointer_validation::validate_function_pointer;
-use fish_11_core::logging;
-use log::{error, info, warn};
-use retour::GenericDetour;
-use std::io;
-use std::sync::PoisonError;
-use windows::Win32::Foundation::FARPROC;
-use windows::Win32::System::LibraryLoader::{GetModuleHandleA, GetProcAddress};
-use windows::core::PCSTR;
 
 /// Initialize the logger
 pub fn init_logger() {

--- a/fish_11_inject/src/hook_socket.rs
+++ b/fish_11_inject/src/hook_socket.rs
@@ -1,21 +1,23 @@
 //! This module contains the hooks for Winsock functions
 //! It includes the hooks for recv, send, connect, and closesocket
 
-use crate::socket::handlers::protocol_detection;
-use crate::socket::info::SocketInfo;
-use crate::socket::state::SocketState;
-use crate::{ACTIVE_SOCKETS, DISCARDED_SOCKETS, ENGINES, InjectEngines};
+use std::ffi::c_int;
+use std::sync::{Arc, Mutex as StdMutex};
+
 use fish_11_core::globals::{
     CMD_JOIN, CMD_NOTICE, CMD_PRIVMSG, KEY_EXCHANGE_INIT, KEY_EXCHANGE_PUBKEY,
 };
 use log::{debug, error, info, trace, warn};
 use retour::{Function, GenericDetour};
 use sha2::{Digest, Sha256};
-use std::ffi::c_int;
-use std::sync::{Arc, Mutex as StdMutex};
 use windows::Win32::Networking::WinSock::{
     SOCKADDR, SOCKET, SOCKET_ERROR, WSAEINTR, WSAEINVAL, WSAGetLastError, WSASetLastError,
 };
+
+use crate::socket::handlers::protocol_detection;
+use crate::socket::info::SocketInfo;
+use crate::socket::state::SocketState;
+use crate::{ACTIVE_SOCKETS, DISCARDED_SOCKETS, ENGINES, InjectEngines};
 
 /// Return [`SOCKET_ERROR`] and set a Winsock error for callers (`WSAGetLastError`).
 #[inline]
@@ -542,10 +544,7 @@ unsafe fn uninstall_one_winsock_hook<T: Copy + Function>(
     ) {
         Ok(g) => g,
         Err(e) => {
-            error!(
-                "uninstall_socket_hooks: timed out acquiring {} mutex: {}",
-                hook_label, e
-            );
+            error!("uninstall_socket_hooks: timed out acquiring {} mutex: {}", hook_label, e);
             return;
         }
     };

--- a/fish_11_inject/src/hook_socket.rs
+++ b/fish_11_inject/src/hook_socket.rs
@@ -44,18 +44,26 @@ const MAXIMUM_PREVIEW_SIZE: usize = 64;
 /// before invoking the returned pointer, or same-thread re-entry into the hook deadlocks on a
 /// non-reentrant `std::sync::Mutex`. (`GenericDetour::trampoline` is `&()`; transmute needs a
 /// concrete function type : see `retour` tests.)
+///
+/// # Safety
+/// - The `hook` must be a valid, installed detour created by `retour::detour`
+/// - The returned function pointer is valid only while the detour is installed
+/// - The caller must not call the returned function while holding the hook mutex
 #[inline]
 unsafe fn recv_detour_original(hook: &GenericDetour<RecvFn>) -> RecvFn {
     std::mem::transmute(hook.trampoline())
 }
+/// SAFETY: Same constraints as `recv_detour_original` above.
 #[inline]
 unsafe fn send_detour_original(hook: &GenericDetour<SendFn>) -> SendFn {
     std::mem::transmute(hook.trampoline())
 }
+/// SAFETY: Same constraints as `recv_detour_original` above.
 #[inline]
 unsafe fn connect_detour_original(hook: &GenericDetour<ConnectFn>) -> ConnectFn {
     std::mem::transmute(hook.trampoline())
 }
+/// SAFETY: Same constraints as `recv_detour_original` above.
 #[inline]
 unsafe fn closesocket_detour_original(hook: &GenericDetour<ClosesocketFn>) -> ClosesocketFn {
     std::mem::transmute(hook.trampoline())
@@ -174,11 +182,37 @@ pub unsafe extern "system" fn hooked_recv(
 
         // Safety: ensure len is non-negative before casting
         let safe_len = if len > 0 { len as usize } else { 0 };
-        let bytes_to_copy = std::cmp::min(safe_len, processed_buffer.len());
+
+        // Only copy complete lines (ending with \r\n) to avoid returning truncated
+        // IRC messages to mIRC, which would corrupt the protocol display.
+        // Find the last \r\n boundary within the mIRC buffer size limit.
+        let boundary = processed_buffer[..std::cmp::min(safe_len, processed_buffer.len())]
+            .windows(2)
+            .rposition(|w| w == b"\r\n")
+            .map(|pos| pos + 2)
+            .unwrap_or(0);
+
+        let bytes_to_copy = boundary;
 
         if bytes_to_copy > 0 {
             let target_buf = std::slice::from_raw_parts_mut(buf, bytes_to_copy);
             target_buf.copy_from_slice(&processed_buffer[..bytes_to_copy]);
+
+            // Return remaining bytes (incomplete trailing data) to the processed buffer
+            // so they survive for the next recv() call.
+            if bytes_to_copy < processed_buffer.len() {
+                let mut remaining = socket_info.processed_incoming_buffer.lock();
+                let leftover = &processed_buffer[bytes_to_copy..];
+                remaining.clear();
+                remaining.extend(leftover);
+
+                #[cfg(debug_assertions)]
+                debug!(
+                    "[RECV DEBUG] socket {}: preserved {} bytes of incomplete trailing data",
+                    s.0,
+                    leftover.len()
+                );
+            }
 
             #[cfg(debug_assertions)]
             {
@@ -189,7 +223,6 @@ pub unsafe extern "system" fn hooked_recv(
                     processed_buffer.len()
                 );
 
-                // Log what we're actually returning
                 if let Ok(text) = std::str::from_utf8(&processed_buffer[..bytes_to_copy]) {
                     info!("[RECV] {}: returning to mIRC: {}", s.0, text.trim_end());
                 } else {
@@ -202,7 +235,7 @@ pub unsafe extern "system" fn hooked_recv(
             }
         }
 
-        // After reading, clear the processed buffer for the next round.
+        // Clear processed buffer — any incomplete trailing data was already preserved above.
         socket_info.clear_processed_buffer();
 
         return bytes_to_copy as c_int;

--- a/fish_11_inject/src/hook_ssl.rs
+++ b/fish_11_inject/src/hook_ssl.rs
@@ -1,17 +1,19 @@
+use std::ffi::{CString, c_int, c_void};
+use std::sync::Mutex as StdMutex;
+
+use log::{debug, error, info, trace, warn};
+use once_cell::sync::Lazy;
+use retour::{Function, GenericDetour};
+use windows::Win32::Foundation::FARPROC;
+use windows::Win32::Networking::WinSock::SOCKET;
+use windows::Win32::System::LibraryLoader::{GetModuleHandleA, GetProcAddress, LoadLibraryA};
+use windows::core::PCSTR;
+
 use crate::helpers_inject::handle_poison;
 use crate::hook_socket::get_or_create_socket;
 use crate::pointer_validation::validate_function_pointer;
 use crate::socket::state::SocketState;
 use crate::ssl_mapping::SslSocketMapping;
-use log::{debug, error, info, trace, warn};
-use once_cell::sync::Lazy;
-use retour::{Function, GenericDetour};
-use std::ffi::{CString, c_int, c_void};
-use std::sync::Mutex as StdMutex;
-use windows::Win32::Foundation::FARPROC;
-use windows::Win32::Networking::WinSock::SOCKET;
-use windows::Win32::System::LibraryLoader::{GetModuleHandleA, GetProcAddress, LoadLibraryA};
-use windows::core::PCSTR;
 
 // SSL structure (opaque)
 #[repr(C)]
@@ -73,15 +75,13 @@ pub static SSL_GET_FD: Lazy<StdMutex<Option<SslGetFdFn>>> = Lazy::new(|| StdMute
 pub static SSL_FREE_HOOK: Lazy<StdMutex<Option<GenericDetour<SslFreeFn>>>> =
     Lazy::new(|| StdMutex::new(None));
 pub static SSL_HOOKS_INSTALLED: Lazy<StdMutex<bool>> = Lazy::new(|| StdMutex::new(false));
-pub static ORIGINAL_SSL_READ: Lazy<StdMutex<Option<SslReadFn>>> =
-    Lazy::new(|| StdMutex::new(None));
+pub static ORIGINAL_SSL_READ: Lazy<StdMutex<Option<SslReadFn>>> = Lazy::new(|| StdMutex::new(None));
 pub static ORIGINAL_SSL_WRITE: Lazy<StdMutex<Option<SslWriteFn>>> =
     Lazy::new(|| StdMutex::new(None));
 pub static ORIGINAL_SSL_CONNECT: Lazy<StdMutex<Option<SslConnectFn>>> =
     Lazy::new(|| StdMutex::new(None));
 pub static ORIGINAL_SSL_NEW: Lazy<StdMutex<Option<SslNewFn>>> = Lazy::new(|| StdMutex::new(None));
-pub static ORIGINAL_SSL_FREE: Lazy<StdMutex<Option<SslFreeFn>>> =
-    Lazy::new(|| StdMutex::new(None));
+pub static ORIGINAL_SSL_FREE: Lazy<StdMutex<Option<SslFreeFn>>> = Lazy::new(|| StdMutex::new(None));
 
 static SSL_SET_FD_HOOK: Lazy<StdMutex<Option<GenericDetour<SslSetFdFn>>>> =
     Lazy::new(|| StdMutex::new(None));
@@ -545,8 +545,7 @@ pub unsafe fn install_ssl_hooks(
     let mut original_ssl_read = ORIGINAL_SSL_READ.lock().unwrap_or_else(handle_poison);
     let mut original_ssl_write = ORIGINAL_SSL_WRITE.lock().unwrap_or_else(handle_poison);
     let mut ssl_get_fd_slot = SSL_GET_FD.lock().unwrap_or_else(handle_poison);
-    let mut ssl_is_init_finished_slot =
-        SSL_IS_INIT_FINISHED.lock().unwrap_or_else(handle_poison);
+    let mut ssl_is_init_finished_slot = SSL_IS_INIT_FINISHED.lock().unwrap_or_else(handle_poison);
 
     *original_ssl_read = Some(ssl_read);
     *original_ssl_write = Some(ssl_write);
@@ -631,10 +630,7 @@ unsafe fn uninstall_one_ssl_detour<T: Copy + Function>(
     ) {
         Ok(g) => g,
         Err(e) => {
-            error!(
-                "uninstall_ssl_hooks: timed out acquiring {} mutex: {}",
-                hook_label, e
-            );
+            error!("uninstall_ssl_hooks: timed out acquiring {} mutex: {}", hook_label, e);
             return;
         }
     };
@@ -647,15 +643,10 @@ unsafe fn uninstall_one_ssl_detour<T: Copy + Function>(
 }
 
 fn clear_ssl_slot<T>(label: &'static str, mutex: &StdMutex<T>, value: T) {
-    match crate::lock_utils::try_lock_timeout(
-        mutex,
-        crate::lock_utils::UNINSTALL_HOOK_LOCK_TIMEOUT,
-    ) {
+    match crate::lock_utils::try_lock_timeout(mutex, crate::lock_utils::UNINSTALL_HOOK_LOCK_TIMEOUT)
+    {
         Ok(mut g) => *g = value,
-        Err(e) => error!(
-            "uninstall_ssl_hooks: timed out clearing {}: {}",
-            label, e
-        ),
+        Err(e) => error!("uninstall_ssl_hooks: timed out clearing {}: {}", label, e),
     }
 }
 

--- a/fish_11_inject/src/hook_ssl.rs
+++ b/fish_11_inject/src/hook_ssl.rs
@@ -23,14 +23,29 @@ pub struct SSLWrapper {
     pub ssl: *mut SSL,
 }
 
+// SAFETY: SSLWrapper is used to track SSL connections across threads.
+// The raw pointer is managed by OpenSSL which provides its own threading guarantees
+// when properly initialized (SSL_library_init / OPENSSL_init_ssl).
+// The pointer is only used for identity comparison and mapping, never dereferenced
+// directly from Rust code - actual SSL operations go through the original SSL_read/SSL_write.
 unsafe impl Send for SSLWrapper {}
 unsafe impl Sync for SSLWrapper {}
 
+// SAFETY: SSL is an opaque OpenSSL structure. We only hold raw pointers to it for
+// socket-to-SSL mapping purposes. All actual SSL operations (read/write/free) are
+// performed through the original OpenSSL function pointers, never through Rust.
+// OpenSSL's threading model (when properly initialized) allows pointer storage across threads.
 unsafe impl Send for SSL {}
 unsafe impl Sync for SSL {}
 
 pub type SslReadFn = unsafe extern "C" fn(*mut SSL, *mut u8, c_int) -> c_int;
 
+/// Extract the original SSL_read function pointer from a detour.
+///
+/// # Safety
+/// - The `hook` must be a valid, installed detour created by `retour::detour`
+/// - The returned function pointer is valid only while the detour is installed
+/// - The caller must not call the returned function while holding the hook mutex
 #[inline]
 unsafe fn ssl_read_detour_original(hook: &GenericDetour<SslReadFn>) -> SslReadFn {
     std::mem::transmute(hook.trampoline())
@@ -68,10 +83,12 @@ pub static ORIGINAL_SSL_NEW: Lazy<StdMutex<Option<SslNewFn>>> = Lazy::new(|| Std
 pub static ORIGINAL_SSL_FREE: Lazy<StdMutex<Option<SslFreeFn>>> =
     Lazy::new(|| StdMutex::new(None));
 
-static SSL_SET_FD_HOOK: StdMutex<Option<GenericDetour<SslSetFdFn>>> = StdMutex::new(None);
+static SSL_SET_FD_HOOK: Lazy<StdMutex<Option<GenericDetour<SslSetFdFn>>>> =
+    Lazy::new(|| StdMutex::new(None));
 
 unsafe extern "C" fn hooked_ssl_set_fd(ssl: *mut SSL, fd: c_int) -> c_int {
-    static ORIGINAL_SSL_SET_FD: StdMutex<Option<SslSetFdFn>> = StdMutex::new(None);
+    static ORIGINAL_SSL_SET_FD: Lazy<StdMutex<Option<SslSetFdFn>>> =
+        Lazy::new(|| StdMutex::new(None));
     trace!("SSL_set_fd() called with ssl: {:p}, fd: {}", ssl, fd);
 
     let original_fn = {
@@ -329,11 +346,36 @@ pub unsafe extern "C" fn hooked_ssl_read(ssl: *mut SSL, buf: *mut u8, num: c_int
     let processed_buffer = socket_info.get_processed_buffer();
 
     let safe_len = if num > 0 { num as usize } else { 0 };
-    let bytes_to_copy = std::cmp::min(safe_len, processed_buffer.len());
+
+    // Only copy complete lines (ending with \r\n) to avoid returning truncated
+    // IRC messages to the application, which would corrupt the protocol.
+    let boundary = processed_buffer[..std::cmp::min(safe_len, processed_buffer.len())]
+        .windows(2)
+        .rposition(|w| w == b"\r\n")
+        .map(|pos| pos + 2)
+        .unwrap_or(0);
+
+    let bytes_to_copy = boundary;
 
     if bytes_to_copy > 0 {
         let target_buf = std::slice::from_raw_parts_mut(buf, bytes_to_copy);
         target_buf.copy_from_slice(&processed_buffer[..bytes_to_copy]);
+
+        // Return remaining bytes (incomplete trailing data) to the processed buffer
+        // so they survive for the next SSL_read call.
+        if bytes_to_copy < processed_buffer.len() {
+            let mut remaining = socket_info.processed_incoming_buffer.lock();
+            let leftover = &processed_buffer[bytes_to_copy..];
+            remaining.clear();
+            remaining.extend(leftover);
+
+            #[cfg(debug_assertions)]
+            debug!(
+                "[SSL_read] socket {}: preserved {} bytes of incomplete trailing data",
+                socket_id,
+                leftover.len()
+            );
+        }
 
         #[cfg(debug_assertions)]
         {

--- a/fish_11_inject/src/lib.rs
+++ b/fish_11_inject/src/lib.rs
@@ -24,16 +24,17 @@ mod pointer_validation;
 pub mod socket;
 mod ssl_detection;
 pub mod ssl_mapping;
+use std::ffi::c_void;
+use std::ptr::null_mut;
+use std::sync::atomic::{AtomicBool, AtomicPtr};
+use std::sync::{Arc, Mutex};
+
 use buffer_pool::BufferPool;
 use dashmap::DashMap;
 use engines::InjectEngines;
 use fish_11_core::globals::{MIRC_HALT, MIRC_IDENTIFIER};
 use once_cell::sync::Lazy;
 use socket::info::SocketInfo;
-use std::ffi::c_void;
-use std::ptr::null_mut;
-use std::sync::atomic::{AtomicBool, AtomicPtr};
-use std::sync::{Arc, Mutex};
 use windows::Win32::Foundation::HMODULE;
 
 /// Global buffer pool for efficient memory management
@@ -43,8 +44,7 @@ pub static BUFFER_POOL: Lazy<Arc<BufferPool>> = Lazy::new(|| BufferPool::new());
 pub static ACTIVE_SOCKETS: Lazy<DashMap<u32, Arc<SocketInfo>>> = Lazy::new(DashMap::new);
 
 pub(crate) static DISCARDED_SOCKETS: Lazy<Mutex<Vec<u32>>> = Lazy::new(|| Mutex::new(Vec::new()));
-pub(crate) static ENGINES: Lazy<Mutex<Option<Arc<InjectEngines>>>> =
-    Lazy::new(|| Mutex::new(None));
+pub(crate) static ENGINES: Lazy<Mutex<Option<Arc<InjectEngines>>>> = Lazy::new(|| Mutex::new(None));
 pub(crate) static DLL_HANDLE: AtomicPtr<c_void> = AtomicPtr::new(null_mut());
 pub(crate) static MAX_MIRC_RETURN_BYTES: Lazy<Mutex<usize>> = Lazy::new(|| Mutex::new(4096));
 

--- a/fish_11_inject/src/lock_utils.rs
+++ b/fish_11_inject/src/lock_utils.rs
@@ -4,14 +4,13 @@
 //! acquiring locks, especially important for hook functions that may be
 //! called during DLL unload or from multiple threads.
 
-use std::sync::{Mutex, MutexGuard, PoisonError};
+use std::sync::{Arc, Mutex, MutexGuard, PoisonError};
 use std::time::Duration;
 
 use log::{error, warn};
 
 use crate::ENGINES;
 use crate::engines::InjectEngines;
-use std::sync::Arc;
 
 /// Default timeout for lock acquisition (100ms)
 pub const DEFAULT_LOCK_TIMEOUT: Duration = Duration::from_millis(100);

--- a/fish_11_inject/src/pointer_validation.rs
+++ b/fish_11_inject/src/pointer_validation.rs
@@ -7,6 +7,14 @@ use windows::Win32::System::Threading::GetCurrentProcess;
 /// Checks:
 /// 1. Is not NULL
 /// 2. Is within the address space of the given module (if module handle provided)
+///
+/// Note: Address-range validation is sufficient here because the pointers being validated
+/// are resolved from the module's export table via `GetProcAddress`. A pointer that falls
+/// within the module's address range was either exported by that module or points to data
+/// within it : both are valid targets for hooking. We cannot meaningfully verify that the
+/// pointer points to executable code without disassembling the instruction stream, which
+/// would add complexity without security benefit in this context (the functions are loaded
+/// from known, trusted OpenSSL libraries).
 pub unsafe fn validate_function_pointer(
     ptr: FARPROC,
     module: Option<HMODULE>,

--- a/fish_11_inject/src/socket/buffers.rs
+++ b/fish_11_inject/src/socket/buffers.rs
@@ -1,5 +1,6 @@
-use super::info::SocketInfo;
 use log::{debug, info, warn};
+
+use super::info::SocketInfo;
 
 impl SocketInfo {
     pub fn write_received_data(&self, data: &[u8]) {

--- a/fish_11_inject/src/socket/handlers/incoming_irc.rs
+++ b/fish_11_inject/src/socket/handlers/incoming_irc.rs
@@ -8,9 +8,13 @@ use crate::socket::info::SocketInfo;
 use crate::socket::state::SocketError;
 
 impl SocketInfo {
-    /// Process received data as UTF-8 lines
+    /// Process received data as UTF-8 lines.
+    ///
+    /// Only complete lines (ending with `\r\n`) are passed to the engine for decryption.
+    /// Any trailing partial data (incomplete line) is preserved in `received_buffer` so
+    /// it can be completed by the next `recv()` call, preventing protocol corruption
+    /// from truncated messages.
     pub fn process_received_lines(&self) -> Result<(), SocketError> {
-        // Get data while handling potential mutex poisoning
         let data = match self.received_buffer.try_lock() {
             Some(mut buffer) => {
                 if buffer.is_empty() {
@@ -28,38 +32,19 @@ impl SocketInfo {
                     );
                 }
 
-                // Process data in chunks to avoid large memory allocations
-                // and release the lock as soon as possible
-                let data_copy = if buffer.len() > 4096 {
-                    // For large buffers, process in chunks
-                    let mut result = Vec::with_capacity(buffer.len());
+                let data_copy = buffer.clone();
 
-                    // Process in 4KB chunks
-                    const CHUNK_SIZE: usize = 4096;
-                    for chunk in buffer.chunks(CHUNK_SIZE) {
-                        result.extend_from_slice(chunk);
-                    }
-
-                    // Compact memory to save space
-                    result.shrink_to_fit();
-                    result
-                } else {
-                    // For small buffers, clone is efficient enough
-                    buffer.clone()
-                };
-
-                // Clear buffer now that we've processed the data
+                // Clear buffer : only consumed bytes will be restored below if partial data remains
                 buffer.clear();
 
                 data_copy
             }
             None => {
-                // Handle mutex acquisition failure gracefully
                 warn!(
                     "Socket {}: could not acquire lock on received_buffer, will retry later",
                     self.socket
                 );
-                return Ok(()); // Return without error to allow retrying later
+                return Ok(());
             }
         };
 
@@ -113,15 +98,22 @@ impl SocketInfo {
                 let mut lines_processed = 0;
                 let mut bytes_processed = 0;
 
-                // Pre-allocate a buffer for lines with adaptive capacity
-                // Estimate initial capacity based on data size
                 let estimated_capacity = std::cmp::min(4096, data.len().saturating_add(64));
                 let mut line_buffer = String::with_capacity(estimated_capacity);
 
-                // Process each line with controlled lock acquisition
-                for line in data_str.split("\r\n") {
+                // Split into lines. The last element may be a partial line (no trailing \r\n).
+                // We only pass complete lines to the engine; partial data is restored into
+                // received_buffer so it survives for the next recv() call.
+                let segments: Vec<&str> = data_str.split("\r\n").collect();
+                let last_segment = segments.last().copied().unwrap_or("");
+
+                for line in segments.iter() {
+                    if line.is_empty() && *line == last_segment && !data_str.ends_with("\r\n") {
+                        // This is a trailing partial line : do NOT process it
+                        break;
+                    }
+
                     if line.is_empty() {
-                        bytes_processed += 2; // Count the \r\n
                         continue;
                     }
 
@@ -129,8 +121,6 @@ impl SocketInfo {
 
                     #[cfg(debug_assertions)]
                     {
-                        // Log details about each IRC line
-
                         debug!(
                             "[PROCESS_LINES DEBUG] socket {}: processing IRC line ({} bytes): {:?}",
                             self.socket,
@@ -138,14 +128,12 @@ impl SocketInfo {
                             line
                         );
 
-                        // Check for specific IRC commands or FiSH markers
                         if line.contains(CMD_PRIVMSG) || line.contains(CMD_NOTICE) {
                             debug!(
                                 "[PROCESS_LINES DEBUG] socket {}: detected IRC message command",
                                 self.socket
                             );
 
-                            // Check for encrypted content markers
                             if line.contains(ENCRYPTION_PREFIX_OK)
                                 || line.contains(ENCRYPTION_PREFIX_FISH)
                                 || line.contains(ENCRYPTION_PREFIX_MCPS)
@@ -165,7 +153,6 @@ impl SocketInfo {
                         }
                     }
 
-                    // Reuse the buffer instead of allocating a new string
                     line_buffer.clear();
                     line_buffer.push_str(line);
                     line_buffer.push_str("\r\n");
@@ -175,13 +162,11 @@ impl SocketInfo {
 
                     bytes_processed += line_buffer.len();
 
-                    // Robust lock handling for stats with recovery strategy
                     match self.stats.try_lock() {
                         Some(mut stats) => {
                             stats.lines_received += 1;
                         }
                         None => {
-                            // Log but continue processing
                             warn!(
                                 "Socket {}: could not update stats, mutex unavailable",
                                 self.socket
@@ -189,31 +174,47 @@ impl SocketInfo {
                         }
                     }
 
-                    // Robust lock handling for processed buffer with recovery strategy
-                    match self.processed_incoming_buffer.try_lock() {
-                        Some(mut buffer) => {
-                            buffer.extend(line_buffer.as_bytes());
+                    // Use blocking lock to prevent silent data loss.
+                    // This is safe because processed_incoming_buffer is only locked here
+                    // and in get_processed_buffer/clear_processed_buffer which run on the
+                    // same thread (recv call stack), so no cross-thread deadlock can occur.
+                    {
+                        let mut buffer = self.processed_incoming_buffer.lock();
+                        buffer.extend(line_buffer.as_bytes());
 
-                            #[cfg(debug_assertions)]
-                            {
-                                debug!(
-                                    "[PROCESS_LINES DEBUG] socket {}: added {} bytes to processed_incoming_buffer (total now: {} bytes)",
-                                    self.socket,
-                                    line_buffer.len(),
-                                    buffer.len()
-                                );
-                            }
-                        }
-                        None => {
-                            // Log but continue with next line
-                            warn!(
-                                "Socket {}: could not update processed buffer, mutex unavailable",
-                                self.socket
+                        #[cfg(debug_assertions)]
+                        {
+                            debug!(
+                                "[PROCESS_LINES DEBUG] socket {}: added {} bytes to processed_incoming_buffer (total now: {} bytes)",
+                                self.socket,
+                                line_buffer.len(),
+                                buffer.len()
                             );
                         }
                     }
 
                     lines_processed += 1;
+                }
+
+                // Restore any trailing partial data into received_buffer so it
+                // survives for the next recv() call and avoids protocol corruption.
+                if !data_str.ends_with("\r\n") && !last_segment.is_empty() {
+                    if let Some(mut buffer) = self.received_buffer.try_lock() {
+                        buffer.extend_from_slice(last_segment.as_bytes());
+                        #[cfg(debug_assertions)]
+                        {
+                            debug!(
+                                "[PROCESS_LINES DEBUG] socket {}: restored {} bytes of partial data to received_buffer",
+                                self.socket,
+                                last_segment.len()
+                            );
+                        }
+                    } else {
+                        warn!(
+                            "Socket {}: could not restore partial data to received_buffer",
+                            self.socket
+                        );
+                    }
                 }
 
                 info!(
@@ -235,47 +236,61 @@ impl SocketInfo {
                 trace!("Socket {}: [IN RAW] Non-UTF8 data", self.socket);
                 warn!("Socket {}: received data contains invalid UTF-8: {}", self.socket, e);
 
-                Err(SocketError::ProtocolError(format!("FromUtf8Error: {}", e)))
+                // Try to salvage what we can: split on \r\n boundaries and process
+                // each segment with lossy UTF-8 conversion. This prevents losing the
+                // entire buffer when a single byte is invalid.
+                let mut lines_processed = 0;
+                let mut line_buffer = String::with_capacity(4096);
+                let segments: Vec<&[u8]> = data.split(|&b| b == b'\r').collect();
+                let last_segment = segments.last().copied().unwrap_or(&[]);
+
+                for segment in segments.iter() {
+                    if segment.is_empty() {
+                        continue;
+                    }
+
+                    // Skip the trailing \n after \r if present
+                    let line_bytes = if segment.last() == Some(&b'\n') {
+                        &segment[..segment.len() - 1]
+                    } else {
+                        segment
+                    };
+
+                    if line_bytes.is_empty() {
+                        continue;
+                    }
+
+                    line_buffer.clear();
+                    line_buffer.push_str(&String::from_utf8_lossy(line_bytes));
+                    line_buffer.push_str("\r\n");
+
+                    self.on_incoming_irc_line(self.socket, &mut line_buffer);
+
+                    if let Some(mut buffer) = self.processed_incoming_buffer.try_lock() {
+                        buffer.extend(line_buffer.as_bytes());
+                    }
+
+                    lines_processed += 1;
+                }
+
+                // Preserve any trailing data that didn't end with \r\n
+                if !data.ends_with(b"\r\n") && !last_segment.is_empty() {
+                    if let Some(mut buffer) = self.received_buffer.try_lock() {
+                        buffer.extend_from_slice(last_segment);
+                    }
+                }
+
+                warn!(
+                    "Socket {}: salvaged {} lines from non-UTF8 data",
+                    self.socket, lines_processed
+                );
+
+                Ok(())
             }
         }
     }
 
     pub fn on_incoming_irc_line(&self, socket: u32, line: &mut String) -> bool {
-        let mut modified = false;
-
-        // Process through normal engines first
-        for engine in self.engines.get_engines() {
-            let before = line.clone();
-            if !engine.is_postprocessor {
-                if engine.on_incoming_irc_line(socket, line) {
-                    modified = true;
-                }
-            }
-            if modified {
-                trace!(
-                    "Socket {}: engine '{}' modified incoming line:\n  Before: {}\n  After:  {}",
-                    socket,
-                    engine.engine_name,
-                    before.trim_end(),
-                    line.trim_end()
-                );
-            } else {
-                trace!(
-                    "Socket {}: engine '{}' did not modify incoming line:",
-                    socket, engine.engine_name
-                );
-            }
-        }
-
-        // Then through postprocessors
-        for engine in self.engines.get_engines() {
-            if engine.is_postprocessor {
-                if engine.on_incoming_irc_line(socket, line) {
-                    modified = true;
-                }
-            }
-        }
-
-        modified
+        self.engines.on_incoming_irc_line(socket, line)
     }
 }

--- a/fish_11_inject/src/socket/handlers/network.rs
+++ b/fish_11_inject/src/socket/handlers/network.rs
@@ -1,5 +1,6 @@
-use crate::socket::info::SocketInfo;
 use log::info;
+
+use crate::socket::info::SocketInfo;
 
 pub fn is_network_info(line: &str) -> bool {
     line.contains(" 005 ")

--- a/fish_11_inject/src/socket/handlers/outgoing_irc.rs
+++ b/fish_11_inject/src/socket/handlers/outgoing_irc.rs
@@ -1,6 +1,7 @@
+use log::{debug, trace, warn};
+
 use crate::socket::info::SocketInfo;
 use crate::socket::state::{SocketError, SocketState};
-use log::{debug, trace, warn};
 
 impl SocketInfo {
     pub fn on_sending(&self, data: &[u8]) -> Result<(), SocketError> {

--- a/fish_11_inject/src/socket/handlers/protocol_detection.rs
+++ b/fish_11_inject/src/socket/handlers/protocol_detection.rs
@@ -1,6 +1,7 @@
+use log::{debug, info, trace};
+
 use crate::socket::info::SocketInfo;
 use crate::socket::state::{SocketError, SocketState};
-use log::{debug, info, trace};
 
 impl SocketInfo {
     /// Handle the first data sent on a connection to identify protocol

--- a/fish_11_inject/src/socket/info.rs
+++ b/fish_11_inject/src/socket/info.rs
@@ -1,8 +1,10 @@
-use super::state::{SocketFlags, SocketState, SocketStats};
-use crate::engines::InjectEngines;
-use parking_lot::{Mutex, RwLock};
 use std::collections::VecDeque;
 use std::sync::Arc;
+
+use parking_lot::{Mutex, RwLock};
+
+use super::state::{SocketFlags, SocketState, SocketStats};
+use crate::engines::InjectEngines;
 
 pub struct SocketInfo {
     pub socket: u32,

--- a/fish_11_inject/src/ssl_detection.rs
+++ b/fish_11_inject/src/ssl_detection.rs
@@ -1,9 +1,11 @@
-use crate::pointer_validation::unsafe_transmute_validated;
-use log::{debug, error};
 use std::ffi::CString;
+
+use log::{debug, error};
 use windows::Win32::Foundation::HMODULE;
 use windows::Win32::System::LibraryLoader::{GetModuleFileNameA, GetProcAddress};
 use windows::core::PCSTR;
+
+use crate::pointer_validation::unsafe_transmute_validated;
 
 #[derive(Debug, Clone)]
 pub struct OpenSslInfo {

--- a/fish_11_inject/src/ssl_mapping.rs
+++ b/fish_11_inject/src/ssl_mapping.rs
@@ -4,10 +4,11 @@
 //! This module provides atomic operations for associating SSL* pointers with
 //! socket IDs, ensuring thread-safe access without risk of race conditions.
 
-use crate::hook_ssl::{SSL, SSLWrapper};
 use dashmap::DashMap;
 use log::{debug, error, trace, warn};
 use once_cell::sync::Lazy;
+
+use crate::hook_ssl::{SSL, SSLWrapper};
 
 /// Global thread-safe mapping from SSL pointer (as usize) to socket ID
 static SSL_TO_SOCKET: Lazy<DashMap<usize, u32>> = Lazy::new(DashMap::new);


### PR DESCRIPTION
Buffer safety (hooked_recv / hooked_ssl_read / process_received_lines)
- Incoming data is now split into complete lines (ending with \r\n) before being passed to the engine for decryption. Previously, TCP-fragmented messages could be partially truncated, causing protocol corruption in mIRC's display.
- Trailing partial data (incomplete lines without \r\n) is preserved in received_buffer so it survives across recv() calls and gets completed when the next TCP segment arrives.
- When filling mIRC's output buffer, only complete lines up to the last \r\n boundary are copied. Any remaining bytes are kept in processed_incoming_buffer for the next read cycle.
Silent data loss prevention (incoming_irc.rs)
- Replaced try_lock() with a blocking lock() on processed_incoming_buffer. Previously, under mutex contention, decrypted messages were silently dropped — now they are reliably enqueued.
Non-UTF8 data handling (incoming_irc.rs)
- When received data contains invalid UTF-8, the buffer is no longer entirely discarded. Instead, each segment is processed individually with lossy UTF-8 conversion, salvaging as many valid IRC lines as possible.
Memory ownership (engine_registration.rs)
- get_network_name_from_inject() now uses CStr::from_ptr + FreeString (the inject DLL's API) instead of CString::from_raw, respecting the correct allocator contract across DLL boundaries.
SmartBuffer double-release (buffer_pool.rs)
- SmartBuffer::drop now uses std::mem::take to move the buffer without cloning before releasing it to the pool, eliminating a wasteful copy.
Engine iteration unification (engines.rs / incoming_irc.rs)
- Added InjectEngines::on_incoming_irc_line() mirroring the existing on_outgoing_irc_line() pattern, replacing the ad-hoc double iteration in SocketInfo::on_incoming_irc_line().
Workspace profile cleanup (Cargo.toml)
- Moved [profile.dev], [profile.release], and [profile.release.package."*"] from all four crate Cargo.toml files to the workspace root, eliminating the "profiles for the non root package will be ignored" warnings.
Pointer validation documentation (pointer_validation.rs)
- Added documentation explaining why address-range validation is sufficient for function pointers resolved from a module's export table.
